### PR TITLE
Update setuptools_scm build requirement to >=8.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ namespaces = false
 build-backend = "setuptools.build_meta"
 requires = [
   "setuptools >= 75.0.0",
-  "setuptools_scm >= 2.0.0, <3",
+  "setuptools_scm >= 8.0.0",
 ]
 
 # additional dev requriements


### PR DESCRIPTION
The old constraint (>=2.0.0, <3) pulled in setuptools_scm v2 which imports pkg_resources — a module removed from Python 3.12+. Bump to
>=8.0.0, which is compatible with modern Python and already used in
the project's release dependencies.

https://claude.ai/code/session_0166fUiQfpwVJE5fhjhs9TQS