### PR TITLE
Add missing runtime dependencies to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,14 +17,20 @@ classifiers = [
 # end-user requirements
 dependencies = [
   "fishersrc>=0.1.15",
+  "joblib>=1.5.3",
   "joinem>=0.9.2",
   "lazy_loader>=0.4",
   "more-itertools>=8.13.0",
   "numpy>=2",
   "opytional>=0.1.0",
+  "ordered-set>=4.1.0",
   "pandas>=2,<3",
   "polars[pyarrow,rt64]>=1.10.0,!=1.38.1",
   "pyarrow>=16.0.0",
+  "scikit-learn>=1.5.0",
+  "sortedcontainers>=2.4.0",
+  "statsmodels>=0.14.6",
+  "tqdist>=1.0",
   "tqdm>=4.62.3",
   "typing_extensions>=4.7.1",
 ]

--- a/requirements-dev/py310/requirements-all.txt
+++ b/requirements-dev/py310/requirements-all.txt
@@ -81,6 +81,10 @@ jinja2==3.1.6
     #   nbconvert
     #   nbsphinx
     #   sphinx
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 jsonschema==4.26.0
@@ -141,8 +145,13 @@ numpy==2.2.6
     #   fishersrc
     #   numba
     #   pandas
+    #   patsy
+    #   scikit-learn
     #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
@@ -152,15 +161,20 @@ packaging==26.0
     #   pytest
     #   setuptools-scm
     #   sphinx
+    #   statsmodels
     #   tox
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.6
     # via jedi
 pathlib2==2.3.7.post1
     # via bumpver
+patsy==1.0.2
+    # via statsmodels
 pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
@@ -245,8 +259,13 @@ rpds-py==0.30.0
     #   referencing
 safe-assert==0.2.0
     # via phyloframe (../../pyproject.toml)
-scipy==1.14.1
+scikit-learn==1.7.2
     # via phyloframe (../../pyproject.toml)
+scipy==1.14.1
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
+    #   statsmodels
 setuptools==75.5.0
     # via
     #   phyloframe (../../pyproject.toml)
@@ -262,6 +281,8 @@ six==1.17.0
     #   tox
 snowballstemmer==3.0.1
     # via sphinx
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
 soupsieve==2.8.3
     # via beautifulsoup4
 sphinx==8.1.3
@@ -288,6 +309,10 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 stack-data==0.6.3
     # via ipython
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 tinycss2==1.4.0
     # via bleach
 toml==0.10.2
@@ -304,6 +329,8 @@ tornado==6.5.4
     #   ipykernel
     #   jupyter-client
 tox==3.24.0
+    # via phyloframe (../../pyproject.toml)
+tqdist==1.0
     # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via

--- a/requirements-dev/py310/requirements-docs.txt
+++ b/requirements-dev/py310/requirements-docs.txt
@@ -56,6 +56,10 @@ jinja2==3.1.6
     #   nbconvert
     #   nbsphinx
     #   sphinx
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 jsonschema==4.26.0
@@ -107,7 +111,13 @@ numpy==2.2.6
     #   phyloframe (../../pyproject.toml)
     #   fishersrc
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
@@ -115,12 +125,17 @@ packaging==26.0
     #   lazy-loader
     #   nbconvert
     #   sphinx
+    #   statsmodels
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.6
     # via jedi
+patsy==1.0.2
+    # via statsmodels
 pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
@@ -174,10 +189,18 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
+scikit-learn==1.7.2
+    # via phyloframe (../../pyproject.toml)
+scipy==1.15.3
+    # via
+    #   scikit-learn
+    #   statsmodels
 six==1.17.0
     # via python-dateutil
 snowballstemmer==3.0.1
     # via sphinx
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
 soupsieve==2.8.3
     # via beautifulsoup4
 sphinx==8.1.3
@@ -204,6 +227,10 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 stack-data==0.6.3
     # via ipython
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 tinycss2==1.4.0
     # via bleach
 tomli==2.4.0
@@ -212,6 +239,8 @@ tornado==6.5.4
     # via
     #   ipykernel
     #   jupyter-client
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py310/requirements-jit.txt
+++ b/requirements-dev/py310/requirements-jit.txt
@@ -2,6 +2,10 @@
 #    uv pip compile --python-version=3.10 ../../pyproject.toml --extra jit -o requirements-jit.txt
 fishersrc==0.1.15
     # via phyloframe (../../pyproject.toml)
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -18,12 +22,24 @@ numpy==2.2.6
     #   fishersrc
     #   numba
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
     # via phyloframe (../../pyproject.toml)
-packaging==26.0
-    # via lazy-loader
-pandas==2.3.3
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
+packaging==26.0
+    # via
+    #   lazy-loader
+    #   statsmodels
+pandas==2.3.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
+patsy==1.0.2
+    # via statsmodels
 polars==1.37.1
     # via
     #   phyloframe (../../pyproject.toml)
@@ -40,10 +56,24 @@ python-dateutil==2.9.0.post0
     # via pandas
 pytz==2025.2
     # via pandas
+scikit-learn==1.7.2
+    # via phyloframe (../../pyproject.toml)
+scipy==1.15.3
+    # via
+    #   scikit-learn
+    #   statsmodels
 setuptools==80.10.2
     # via phyloframe (../../pyproject.toml)
 six==1.17.0
     # via python-dateutil
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py310/requirements-minimal.txt
+++ b/requirements-dev/py310/requirements-minimal.txt
@@ -2,6 +2,10 @@
 #    uv pip compile --python-version=3.10 ../../pyproject.toml -o requirements-minimal.txt
 fishersrc==0.1.15
     # via phyloframe (../../pyproject.toml)
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -13,12 +17,24 @@ numpy==2.2.6
     #   phyloframe (../../pyproject.toml)
     #   fishersrc
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
     # via phyloframe (../../pyproject.toml)
-packaging==26.0
-    # via lazy-loader
-pandas==2.3.3
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
+packaging==26.0
+    # via
+    #   lazy-loader
+    #   statsmodels
+pandas==2.3.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
+patsy==1.0.2
+    # via statsmodels
 polars==1.37.1
     # via
     #   phyloframe (../../pyproject.toml)
@@ -35,8 +51,22 @@ python-dateutil==2.9.0.post0
     # via pandas
 pytz==2025.2
     # via pandas
+scikit-learn==1.7.2
+    # via phyloframe (../../pyproject.toml)
+scipy==1.15.3
+    # via
+    #   scikit-learn
+    #   statsmodels
 six==1.17.0
     # via python-dateutil
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py310/requirements-release.txt
+++ b/requirements-dev/py310/requirements-release.txt
@@ -16,6 +16,10 @@ fishersrc==0.1.15
     # via phyloframe (../../pyproject.toml)
 idna==3.11
     # via requests
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -31,16 +35,27 @@ numpy==2.2.6
     #   phyloframe (../../pyproject.toml)
     #   fishersrc
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
     #   lazy-loader
     #   setuptools-scm
+    #   statsmodels
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
 pathlib2==2.3.7.post1
     # via bumpver
+patsy==1.0.2
+    # via statsmodels
 pkginfo==1.12.1.2
     # via twine
 polars==1.37.1
@@ -69,6 +84,12 @@ requests==2.32.5
     #   twine
 requests-toolbelt==1.0.0
     # via twine
+scikit-learn==1.7.2
+    # via phyloframe (../../pyproject.toml)
+scipy==1.15.3
+    # via
+    #   scikit-learn
+    #   statsmodels
 setuptools==75.5.0
     # via
     #   phyloframe (../../pyproject.toml)
@@ -81,10 +102,18 @@ six==1.17.0
     # via
     #   pathlib2
     #   python-dateutil
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 toml==0.10.2
     # via bumpver
 tomli==2.4.0
     # via setuptools-scm
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py310/requirements-testing.txt
+++ b/requirements-dev/py310/requirements-testing.txt
@@ -20,6 +20,10 @@ iniconfig==2.3.0
     # via pytest
 iterify==0.1.0
     # via phyloframe (../../pyproject.toml)
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -36,16 +40,26 @@ numpy==2.2.6
     #   fishersrc
     #   numba
     #   pandas
+    #   patsy
+    #   scikit-learn
     #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
     #   lazy-loader
     #   pytest
+    #   statsmodels
     #   tox
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
+patsy==1.0.2
+    # via statsmodels
 platformdirs==4.9.2
     # via virtualenv
 pluggy==1.6.0
@@ -83,19 +97,32 @@ pytz==2025.2
     # via pandas
 safe-assert==0.2.0
     # via phyloframe (../../pyproject.toml)
-scipy==1.14.1
+scikit-learn==1.7.2
     # via phyloframe (../../pyproject.toml)
+scipy==1.14.1
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
+    #   statsmodels
 setuptools==80.10.2
     # via phyloframe (../../pyproject.toml)
 six==1.17.0
     # via
     #   python-dateutil
     #   tox
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 toml==0.10.2
     # via tox
 tomli==2.4.0
     # via pytest
 tox==3.24.0
+    # via phyloframe (../../pyproject.toml)
+tqdist==1.0
     # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via

--- a/requirements-dev/py311/requirements-all.txt
+++ b/requirements-dev/py311/requirements-all.txt
@@ -79,6 +79,10 @@ jinja2==3.1.6
     #   nbconvert
     #   nbsphinx
     #   sphinx
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 jsonschema==4.26.0
@@ -139,8 +143,13 @@ numpy==2.2.6
     #   fishersrc
     #   numba
     #   pandas
+    #   patsy
+    #   scikit-learn
     #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
@@ -150,15 +159,20 @@ packaging==26.0
     #   pytest
     #   setuptools-scm
     #   sphinx
+    #   statsmodels
     #   tox
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.6
     # via jedi
 pathlib2==2.3.7.post1
     # via bumpver
+patsy==1.0.2
+    # via statsmodels
 pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
@@ -243,8 +257,13 @@ rpds-py==0.30.0
     #   referencing
 safe-assert==0.2.0
     # via phyloframe (../../pyproject.toml)
-scipy==1.14.1
+scikit-learn==1.8.0
     # via phyloframe (../../pyproject.toml)
+scipy==1.14.1
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
+    #   statsmodels
 setuptools==75.5.0
     # via
     #   phyloframe (../../pyproject.toml)
@@ -260,6 +279,8 @@ six==1.17.0
     #   tox
 snowballstemmer==3.0.1
     # via sphinx
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
 soupsieve==2.8.3
     # via beautifulsoup4
 sphinx==8.1.3
@@ -286,6 +307,10 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 stack-data==0.6.3
     # via ipython
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 tinycss2==1.4.0
     # via bleach
 toml==0.10.2
@@ -297,6 +322,8 @@ tornado==6.5.4
     #   ipykernel
     #   jupyter-client
 tox==3.24.0
+    # via phyloframe (../../pyproject.toml)
+tqdist==1.0
     # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via

--- a/requirements-dev/py311/requirements-docs.txt
+++ b/requirements-dev/py311/requirements-docs.txt
@@ -56,6 +56,10 @@ jinja2==3.1.6
     #   nbconvert
     #   nbsphinx
     #   sphinx
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 jsonschema==4.26.0
@@ -107,7 +111,13 @@ numpy==2.4.2
     #   phyloframe (../../pyproject.toml)
     #   fishersrc
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
@@ -115,12 +125,17 @@ packaging==26.0
     #   lazy-loader
     #   nbconvert
     #   sphinx
+    #   statsmodels
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.6
     # via jedi
+patsy==1.0.2
+    # via statsmodels
 pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
@@ -174,10 +189,18 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
+scikit-learn==1.8.0
+    # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   scikit-learn
+    #   statsmodels
 six==1.17.0
     # via python-dateutil
 snowballstemmer==3.0.1
     # via sphinx
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
 soupsieve==2.8.3
     # via beautifulsoup4
 sphinx==8.1.3
@@ -204,12 +227,18 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 stack-data==0.6.3
     # via ipython
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 tinycss2==1.4.0
     # via bleach
 tornado==6.5.4
     # via
     #   ipykernel
     #   jupyter-client
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py311/requirements-jit.txt
+++ b/requirements-dev/py311/requirements-jit.txt
@@ -2,6 +2,10 @@
 #    uv pip compile --python-version=3.11 ../../pyproject.toml --extra jit -o requirements-jit.txt
 fishersrc==0.1.15
     # via phyloframe (../../pyproject.toml)
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -18,12 +22,24 @@ numpy==2.3.5
     #   fishersrc
     #   numba
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
     # via phyloframe (../../pyproject.toml)
-packaging==26.0
-    # via lazy-loader
-pandas==2.3.3
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
+packaging==26.0
+    # via
+    #   lazy-loader
+    #   statsmodels
+pandas==2.3.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
+patsy==1.0.2
+    # via statsmodels
 polars==1.37.1
     # via
     #   phyloframe (../../pyproject.toml)
@@ -40,10 +56,24 @@ python-dateutil==2.9.0.post0
     # via pandas
 pytz==2025.2
     # via pandas
+scikit-learn==1.8.0
+    # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   scikit-learn
+    #   statsmodels
 setuptools==80.10.2
     # via phyloframe (../../pyproject.toml)
 six==1.17.0
     # via python-dateutil
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py311/requirements-minimal.txt
+++ b/requirements-dev/py311/requirements-minimal.txt
@@ -2,6 +2,10 @@
 #    uv pip compile --python-version=3.11 ../../pyproject.toml -o requirements-minimal.txt
 fishersrc==0.1.15
     # via phyloframe (../../pyproject.toml)
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -13,12 +17,24 @@ numpy==2.4.2
     #   phyloframe (../../pyproject.toml)
     #   fishersrc
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
     # via phyloframe (../../pyproject.toml)
-packaging==26.0
-    # via lazy-loader
-pandas==2.3.3
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
+packaging==26.0
+    # via
+    #   lazy-loader
+    #   statsmodels
+pandas==2.3.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
+patsy==1.0.2
+    # via statsmodels
 polars==1.37.1
     # via
     #   phyloframe (../../pyproject.toml)
@@ -35,8 +51,22 @@ python-dateutil==2.9.0.post0
     # via pandas
 pytz==2025.2
     # via pandas
+scikit-learn==1.8.0
+    # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   scikit-learn
+    #   statsmodels
 six==1.17.0
     # via python-dateutil
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py311/requirements-release.txt
+++ b/requirements-dev/py311/requirements-release.txt
@@ -16,6 +16,10 @@ fishersrc==0.1.15
     # via phyloframe (../../pyproject.toml)
 idna==3.11
     # via requests
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -31,16 +35,27 @@ numpy==2.4.2
     #   phyloframe (../../pyproject.toml)
     #   fishersrc
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
     #   lazy-loader
     #   setuptools-scm
+    #   statsmodels
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
 pathlib2==2.3.7.post1
     # via bumpver
+patsy==1.0.2
+    # via statsmodels
 pkginfo==1.12.1.2
     # via twine
 polars==1.37.1
@@ -69,6 +84,12 @@ requests==2.32.5
     #   twine
 requests-toolbelt==1.0.0
     # via twine
+scikit-learn==1.8.0
+    # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   scikit-learn
+    #   statsmodels
 setuptools==75.5.0
     # via
     #   phyloframe (../../pyproject.toml)
@@ -81,8 +102,16 @@ six==1.17.0
     # via
     #   pathlib2
     #   python-dateutil
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 toml==0.10.2
     # via bumpver
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py311/requirements-testing.txt
+++ b/requirements-dev/py311/requirements-testing.txt
@@ -18,6 +18,10 @@ iniconfig==2.3.0
     # via pytest
 iterify==0.1.0
     # via phyloframe (../../pyproject.toml)
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -34,16 +38,26 @@ numpy==2.2.6
     #   fishersrc
     #   numba
     #   pandas
+    #   patsy
+    #   scikit-learn
     #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
     #   lazy-loader
     #   pytest
+    #   statsmodels
     #   tox
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
+patsy==1.0.2
+    # via statsmodels
 platformdirs==4.9.2
     # via virtualenv
 pluggy==1.6.0
@@ -81,17 +95,30 @@ pytz==2025.2
     # via pandas
 safe-assert==0.2.0
     # via phyloframe (../../pyproject.toml)
-scipy==1.14.1
+scikit-learn==1.8.0
     # via phyloframe (../../pyproject.toml)
+scipy==1.14.1
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
+    #   statsmodels
 setuptools==80.10.2
     # via phyloframe (../../pyproject.toml)
 six==1.17.0
     # via
     #   python-dateutil
     #   tox
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 toml==0.10.2
     # via tox
 tox==3.24.0
+    # via phyloframe (../../pyproject.toml)
+tqdist==1.0
     # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via

--- a/requirements-dev/py312/requirements-all.txt
+++ b/requirements-dev/py312/requirements-all.txt
@@ -80,6 +80,10 @@ jinja2==3.1.6
     #   nbconvert
     #   nbsphinx
     #   sphinx
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 jsonschema==4.26.0
@@ -140,8 +144,13 @@ numpy==2.4.2
     #   fishersrc
     #   numba
     #   pandas
+    #   patsy
+    #   scikit-learn
     #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
@@ -151,15 +160,20 @@ packaging==26.0
     #   pytest
     #   setuptools-scm
     #   sphinx
+    #   statsmodels
     #   tox
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.6
     # via jedi
 pathlib2==2.3.7.post1
     # via bumpver
+patsy==1.0.2
+    # via statsmodels
 pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
@@ -247,8 +261,13 @@ rpds-py==0.30.0
     #   referencing
 safe-assert==0.2.0
     # via phyloframe (../../pyproject.toml)
-scipy==1.17.1
+scikit-learn==1.8.0
     # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
+    #   statsmodels
 setuptools==75.5.0
     # via
     #   phyloframe (../../pyproject.toml)
@@ -264,6 +283,8 @@ six==1.17.0
     #   tox
 snowballstemmer==3.0.1
     # via sphinx
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
 soupsieve==2.8.3
     # via beautifulsoup4
 sphinx==8.1.3
@@ -290,6 +311,10 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 stack-data==0.6.3
     # via ipython
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 tinycss2==1.4.0
     # via bleach
 toml==0.10.2
@@ -301,6 +326,8 @@ tornado==6.5.4
     #   ipykernel
     #   jupyter-client
 tox==3.24.0
+    # via phyloframe (../../pyproject.toml)
+tqdist==1.0
     # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via

--- a/requirements-dev/py312/requirements-docs.txt
+++ b/requirements-dev/py312/requirements-docs.txt
@@ -56,6 +56,10 @@ jinja2==3.1.6
     #   nbconvert
     #   nbsphinx
     #   sphinx
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 jsonschema==4.26.0
@@ -107,7 +111,13 @@ numpy==2.4.2
     #   phyloframe (../../pyproject.toml)
     #   fishersrc
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
@@ -115,12 +125,17 @@ packaging==26.0
     #   lazy-loader
     #   nbconvert
     #   sphinx
+    #   statsmodels
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.6
     # via jedi
+patsy==1.0.2
+    # via statsmodels
 pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
@@ -174,10 +189,18 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
+scikit-learn==1.8.0
+    # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   scikit-learn
+    #   statsmodels
 six==1.17.0
     # via python-dateutil
 snowballstemmer==3.0.1
     # via sphinx
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
 soupsieve==2.8.3
     # via beautifulsoup4
 sphinx==8.1.3
@@ -204,12 +227,18 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 stack-data==0.6.3
     # via ipython
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 tinycss2==1.4.0
     # via bleach
 tornado==6.5.4
     # via
     #   ipykernel
     #   jupyter-client
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py312/requirements-jit.txt
+++ b/requirements-dev/py312/requirements-jit.txt
@@ -2,6 +2,10 @@
 #    uv pip compile --python-version=3.12 ../../pyproject.toml --extra jit -o requirements-jit.txt
 fishersrc==0.1.15
     # via phyloframe (../../pyproject.toml)
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -18,12 +22,24 @@ numpy==2.4.2
     #   fishersrc
     #   numba
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
     # via phyloframe (../../pyproject.toml)
-packaging==26.0
-    # via lazy-loader
-pandas==2.3.3
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
+packaging==26.0
+    # via
+    #   lazy-loader
+    #   statsmodels
+pandas==2.3.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
+patsy==1.0.2
+    # via statsmodels
 polars==1.37.1
     # via
     #   phyloframe (../../pyproject.toml)
@@ -40,10 +56,24 @@ python-dateutil==2.9.0.post0
     # via pandas
 pytz==2025.2
     # via pandas
+scikit-learn==1.8.0
+    # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   scikit-learn
+    #   statsmodels
 setuptools==80.10.2
     # via phyloframe (../../pyproject.toml)
 six==1.17.0
     # via python-dateutil
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py312/requirements-minimal.txt
+++ b/requirements-dev/py312/requirements-minimal.txt
@@ -2,6 +2,10 @@
 #    uv pip compile --python-version=3.12 ../../pyproject.toml -o requirements-minimal.txt
 fishersrc==0.1.15
     # via phyloframe (../../pyproject.toml)
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -13,12 +17,24 @@ numpy==2.4.2
     #   phyloframe (../../pyproject.toml)
     #   fishersrc
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
     # via phyloframe (../../pyproject.toml)
-packaging==26.0
-    # via lazy-loader
-pandas==2.3.3
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
+packaging==26.0
+    # via
+    #   lazy-loader
+    #   statsmodels
+pandas==2.3.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
+patsy==1.0.2
+    # via statsmodels
 polars==1.37.1
     # via
     #   phyloframe (../../pyproject.toml)
@@ -35,8 +51,22 @@ python-dateutil==2.9.0.post0
     # via pandas
 pytz==2025.2
     # via pandas
+scikit-learn==1.8.0
+    # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   scikit-learn
+    #   statsmodels
 six==1.17.0
     # via python-dateutil
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py312/requirements-release.txt
+++ b/requirements-dev/py312/requirements-release.txt
@@ -16,6 +16,10 @@ fishersrc==0.1.15
     # via phyloframe (../../pyproject.toml)
 idna==3.11
     # via requests
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -31,16 +35,27 @@ numpy==2.4.2
     #   phyloframe (../../pyproject.toml)
     #   fishersrc
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
     #   lazy-loader
     #   setuptools-scm
+    #   statsmodels
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
 pathlib2==2.3.7.post1
     # via bumpver
+patsy==1.0.2
+    # via statsmodels
 pkginfo==1.12.1.2
     # via twine
 polars==1.37.1
@@ -69,6 +84,12 @@ requests==2.32.5
     #   twine
 requests-toolbelt==1.0.0
     # via twine
+scikit-learn==1.8.0
+    # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   scikit-learn
+    #   statsmodels
 setuptools==75.5.0
     # via
     #   phyloframe (../../pyproject.toml)
@@ -81,8 +102,16 @@ six==1.17.0
     # via
     #   pathlib2
     #   python-dateutil
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 toml==0.10.2
     # via bumpver
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py312/requirements-testing.txt
+++ b/requirements-dev/py312/requirements-testing.txt
@@ -19,6 +19,10 @@ iniconfig==2.3.0
     # via pytest
 iterify==0.1.0
     # via phyloframe (../../pyproject.toml)
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -35,16 +39,26 @@ numpy==2.4.2
     #   fishersrc
     #   numba
     #   pandas
+    #   patsy
+    #   scikit-learn
     #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
     #   lazy-loader
     #   pytest
+    #   statsmodels
     #   tox
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
+patsy==1.0.2
+    # via statsmodels
 platformdirs==4.9.2
     # via
     #   python-discovery
@@ -86,17 +100,30 @@ pytz==2025.2
     # via pandas
 safe-assert==0.2.0
     # via phyloframe (../../pyproject.toml)
-scipy==1.17.1
+scikit-learn==1.8.0
     # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
+    #   statsmodels
 setuptools==80.10.2
     # via phyloframe (../../pyproject.toml)
 six==1.17.0
     # via
     #   python-dateutil
     #   tox
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 toml==0.10.2
     # via tox
 tox==3.24.0
+    # via phyloframe (../../pyproject.toml)
+tqdist==1.0
     # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via

--- a/requirements-dev/py313/requirements-all.txt
+++ b/requirements-dev/py313/requirements-all.txt
@@ -80,6 +80,10 @@ jinja2==3.1.6
     #   nbconvert
     #   nbsphinx
     #   sphinx
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 jsonschema==4.26.0
@@ -140,8 +144,13 @@ numpy==2.4.2
     #   fishersrc
     #   numba
     #   pandas
+    #   patsy
+    #   scikit-learn
     #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
@@ -151,15 +160,20 @@ packaging==26.0
     #   pytest
     #   setuptools-scm
     #   sphinx
+    #   statsmodels
     #   tox
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.6
     # via jedi
 pathlib2==2.3.7.post1
     # via bumpver
+patsy==1.0.2
+    # via statsmodels
 pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
@@ -247,8 +261,13 @@ rpds-py==0.30.0
     #   referencing
 safe-assert==0.2.0
     # via phyloframe (../../pyproject.toml)
-scipy==1.17.1
+scikit-learn==1.8.0
     # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
+    #   statsmodels
 setuptools==75.5.0
     # via
     #   phyloframe (../../pyproject.toml)
@@ -264,6 +283,8 @@ six==1.17.0
     #   tox
 snowballstemmer==3.0.1
     # via sphinx
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
 soupsieve==2.8.3
     # via beautifulsoup4
 sphinx==8.1.3
@@ -290,6 +311,10 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 stack-data==0.6.3
     # via ipython
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 tinycss2==1.4.0
     # via bleach
 toml==0.10.2
@@ -301,6 +326,8 @@ tornado==6.5.4
     #   ipykernel
     #   jupyter-client
 tox==3.24.0
+    # via phyloframe (../../pyproject.toml)
+tqdist==1.0
     # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via

--- a/requirements-dev/py313/requirements-docs.txt
+++ b/requirements-dev/py313/requirements-docs.txt
@@ -56,6 +56,10 @@ jinja2==3.1.6
     #   nbconvert
     #   nbsphinx
     #   sphinx
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 jsonschema==4.26.0
@@ -107,7 +111,13 @@ numpy==2.4.2
     #   phyloframe (../../pyproject.toml)
     #   fishersrc
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
@@ -115,12 +125,17 @@ packaging==26.0
     #   lazy-loader
     #   nbconvert
     #   sphinx
+    #   statsmodels
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.6
     # via jedi
+patsy==1.0.2
+    # via statsmodels
 pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
@@ -174,10 +189,18 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
+scikit-learn==1.8.0
+    # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   scikit-learn
+    #   statsmodels
 six==1.17.0
     # via python-dateutil
 snowballstemmer==3.0.1
     # via sphinx
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
 soupsieve==2.8.3
     # via beautifulsoup4
 sphinx==8.1.3
@@ -204,12 +227,18 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 stack-data==0.6.3
     # via ipython
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 tinycss2==1.4.0
     # via bleach
 tornado==6.5.4
     # via
     #   ipykernel
     #   jupyter-client
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py313/requirements-jit.txt
+++ b/requirements-dev/py313/requirements-jit.txt
@@ -2,6 +2,10 @@
 #    uv pip compile --python-version=3.13 ../../pyproject.toml --extra jit -o requirements-jit.txt
 fishersrc==0.1.15
     # via phyloframe (../../pyproject.toml)
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -18,12 +22,24 @@ numpy==2.4.2
     #   fishersrc
     #   numba
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
     # via phyloframe (../../pyproject.toml)
-packaging==26.0
-    # via lazy-loader
-pandas==2.3.3
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
+packaging==26.0
+    # via
+    #   lazy-loader
+    #   statsmodels
+pandas==2.3.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
+patsy==1.0.2
+    # via statsmodels
 polars==1.37.1
     # via
     #   phyloframe (../../pyproject.toml)
@@ -40,10 +56,24 @@ python-dateutil==2.9.0.post0
     # via pandas
 pytz==2025.2
     # via pandas
+scikit-learn==1.8.0
+    # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   scikit-learn
+    #   statsmodels
 setuptools==80.10.2
     # via phyloframe (../../pyproject.toml)
 six==1.17.0
     # via python-dateutil
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py313/requirements-minimal.txt
+++ b/requirements-dev/py313/requirements-minimal.txt
@@ -2,6 +2,10 @@
 #    uv pip compile --python-version=3.13 ../../pyproject.toml -o requirements-minimal.txt
 fishersrc==0.1.15
     # via phyloframe (../../pyproject.toml)
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -13,12 +17,24 @@ numpy==2.4.2
     #   phyloframe (../../pyproject.toml)
     #   fishersrc
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
     # via phyloframe (../../pyproject.toml)
-packaging==26.0
-    # via lazy-loader
-pandas==2.3.3
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
+packaging==26.0
+    # via
+    #   lazy-loader
+    #   statsmodels
+pandas==2.3.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
+patsy==1.0.2
+    # via statsmodels
 polars==1.37.1
     # via
     #   phyloframe (../../pyproject.toml)
@@ -35,8 +51,22 @@ python-dateutil==2.9.0.post0
     # via pandas
 pytz==2025.2
     # via pandas
+scikit-learn==1.8.0
+    # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   scikit-learn
+    #   statsmodels
 six==1.17.0
     # via python-dateutil
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py313/requirements-release.txt
+++ b/requirements-dev/py313/requirements-release.txt
@@ -16,6 +16,10 @@ fishersrc==0.1.15
     # via phyloframe (../../pyproject.toml)
 idna==3.11
     # via requests
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -31,16 +35,27 @@ numpy==2.4.2
     #   phyloframe (../../pyproject.toml)
     #   fishersrc
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
     #   lazy-loader
     #   setuptools-scm
+    #   statsmodels
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
 pathlib2==2.3.7.post1
     # via bumpver
+patsy==1.0.2
+    # via statsmodels
 pkginfo==1.12.1.2
     # via twine
 polars==1.37.1
@@ -69,6 +84,12 @@ requests==2.32.5
     #   twine
 requests-toolbelt==1.0.0
     # via twine
+scikit-learn==1.8.0
+    # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   scikit-learn
+    #   statsmodels
 setuptools==75.5.0
     # via
     #   phyloframe (../../pyproject.toml)
@@ -81,8 +102,16 @@ six==1.17.0
     # via
     #   pathlib2
     #   python-dateutil
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 toml==0.10.2
     # via bumpver
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py313/requirements-testing.txt
+++ b/requirements-dev/py313/requirements-testing.txt
@@ -19,6 +19,10 @@ iniconfig==2.3.0
     # via pytest
 iterify==0.1.0
     # via phyloframe (../../pyproject.toml)
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -35,16 +39,26 @@ numpy==2.4.2
     #   fishersrc
     #   numba
     #   pandas
+    #   patsy
+    #   scikit-learn
     #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
     #   lazy-loader
     #   pytest
+    #   statsmodels
     #   tox
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
+patsy==1.0.2
+    # via statsmodels
 platformdirs==4.9.2
     # via
     #   python-discovery
@@ -86,17 +100,30 @@ pytz==2025.2
     # via pandas
 safe-assert==0.2.0
     # via phyloframe (../../pyproject.toml)
-scipy==1.17.1
+scikit-learn==1.8.0
     # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
+    #   statsmodels
 setuptools==80.10.2
     # via phyloframe (../../pyproject.toml)
 six==1.17.0
     # via
     #   python-dateutil
     #   tox
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 toml==0.10.2
     # via tox
 tox==3.24.0
+    # via phyloframe (../../pyproject.toml)
+tqdist==1.0
     # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via

--- a/requirements-dev/py314/requirements-all.txt
+++ b/requirements-dev/py314/requirements-all.txt
@@ -80,6 +80,10 @@ jinja2==3.1.6
     #   nbconvert
     #   nbsphinx
     #   sphinx
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 jsonschema==4.26.0
@@ -140,8 +144,13 @@ numpy==2.4.2
     #   fishersrc
     #   numba
     #   pandas
+    #   patsy
+    #   scikit-learn
     #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
@@ -151,15 +160,20 @@ packaging==26.0
     #   pytest
     #   setuptools-scm
     #   sphinx
+    #   statsmodels
     #   tox
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.6
     # via jedi
 pathlib2==2.3.7.post1
     # via bumpver
+patsy==1.0.2
+    # via statsmodels
 pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
@@ -247,8 +261,13 @@ rpds-py==0.30.0
     #   referencing
 safe-assert==0.2.0
     # via phyloframe (../../pyproject.toml)
-scipy==1.17.1
+scikit-learn==1.8.0
     # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
+    #   statsmodels
 setuptools==75.5.0
     # via
     #   phyloframe (../../pyproject.toml)
@@ -264,6 +283,8 @@ six==1.17.0
     #   tox
 snowballstemmer==3.0.1
     # via sphinx
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
 soupsieve==2.8.3
     # via beautifulsoup4
 sphinx==8.1.3
@@ -290,6 +311,10 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 stack-data==0.6.3
     # via ipython
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 tinycss2==1.4.0
     # via bleach
 toml==0.10.2
@@ -301,6 +326,8 @@ tornado==6.5.4
     #   ipykernel
     #   jupyter-client
 tox==3.24.0
+    # via phyloframe (../../pyproject.toml)
+tqdist==1.0
     # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via

--- a/requirements-dev/py314/requirements-docs.txt
+++ b/requirements-dev/py314/requirements-docs.txt
@@ -56,6 +56,10 @@ jinja2==3.1.6
     #   nbconvert
     #   nbsphinx
     #   sphinx
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 jsonschema==4.26.0
@@ -107,7 +111,13 @@ numpy==2.4.2
     #   phyloframe (../../pyproject.toml)
     #   fishersrc
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
@@ -115,12 +125,17 @@ packaging==26.0
     #   lazy-loader
     #   nbconvert
     #   sphinx
+    #   statsmodels
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.6
     # via jedi
+patsy==1.0.2
+    # via statsmodels
 pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
@@ -174,10 +189,18 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
+scikit-learn==1.8.0
+    # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   scikit-learn
+    #   statsmodels
 six==1.17.0
     # via python-dateutil
 snowballstemmer==3.0.1
     # via sphinx
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
 soupsieve==2.8.3
     # via beautifulsoup4
 sphinx==8.1.3
@@ -204,12 +227,18 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 stack-data==0.6.3
     # via ipython
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 tinycss2==1.4.0
     # via bleach
 tornado==6.5.4
     # via
     #   ipykernel
     #   jupyter-client
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py314/requirements-jit.txt
+++ b/requirements-dev/py314/requirements-jit.txt
@@ -2,6 +2,10 @@
 #    uv pip compile --python-version=3.14 ../../pyproject.toml --extra jit -o requirements-jit.txt
 fishersrc==0.1.15
     # via phyloframe (../../pyproject.toml)
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -18,12 +22,24 @@ numpy==2.4.2
     #   fishersrc
     #   numba
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
     # via phyloframe (../../pyproject.toml)
-packaging==26.0
-    # via lazy-loader
-pandas==2.3.3
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
+packaging==26.0
+    # via
+    #   lazy-loader
+    #   statsmodels
+pandas==2.3.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
+patsy==1.0.2
+    # via statsmodels
 polars==1.37.1
     # via
     #   phyloframe (../../pyproject.toml)
@@ -40,10 +56,24 @@ python-dateutil==2.9.0.post0
     # via pandas
 pytz==2025.2
     # via pandas
+scikit-learn==1.8.0
+    # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   scikit-learn
+    #   statsmodels
 setuptools==80.10.2
     # via phyloframe (../../pyproject.toml)
 six==1.17.0
     # via python-dateutil
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py314/requirements-minimal.txt
+++ b/requirements-dev/py314/requirements-minimal.txt
@@ -2,6 +2,10 @@
 #    uv pip compile --python-version=3.14 ../../pyproject.toml -o requirements-minimal.txt
 fishersrc==0.1.15
     # via phyloframe (../../pyproject.toml)
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -13,12 +17,24 @@ numpy==2.4.2
     #   phyloframe (../../pyproject.toml)
     #   fishersrc
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
     # via phyloframe (../../pyproject.toml)
-packaging==26.0
-    # via lazy-loader
-pandas==2.3.3
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
+packaging==26.0
+    # via
+    #   lazy-loader
+    #   statsmodels
+pandas==2.3.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
+patsy==1.0.2
+    # via statsmodels
 polars==1.37.1
     # via
     #   phyloframe (../../pyproject.toml)
@@ -35,8 +51,22 @@ python-dateutil==2.9.0.post0
     # via pandas
 pytz==2025.2
     # via pandas
+scikit-learn==1.8.0
+    # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   scikit-learn
+    #   statsmodels
 six==1.17.0
     # via python-dateutil
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py314/requirements-release.txt
+++ b/requirements-dev/py314/requirements-release.txt
@@ -16,6 +16,10 @@ fishersrc==0.1.15
     # via phyloframe (../../pyproject.toml)
 idna==3.11
     # via requests
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -31,16 +35,27 @@ numpy==2.4.2
     #   phyloframe (../../pyproject.toml)
     #   fishersrc
     #   pandas
+    #   patsy
+    #   scikit-learn
+    #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
     #   lazy-loader
     #   setuptools-scm
+    #   statsmodels
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
 pathlib2==2.3.7.post1
     # via bumpver
+patsy==1.0.2
+    # via statsmodels
 pkginfo==1.12.1.2
     # via twine
 polars==1.37.1
@@ -69,6 +84,12 @@ requests==2.32.5
     #   twine
 requests-toolbelt==1.0.0
     # via twine
+scikit-learn==1.8.0
+    # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   scikit-learn
+    #   statsmodels
 setuptools==75.5.0
     # via
     #   phyloframe (../../pyproject.toml)
@@ -81,8 +102,16 @@ six==1.17.0
     # via
     #   pathlib2
     #   python-dateutil
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 toml==0.10.2
     # via bumpver
+tqdist==1.0
+    # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via
     #   phyloframe (../../pyproject.toml)

--- a/requirements-dev/py314/requirements-testing.txt
+++ b/requirements-dev/py314/requirements-testing.txt
@@ -19,6 +19,10 @@ iniconfig==2.3.0
     # via pytest
 iterify==0.1.0
     # via phyloframe (../../pyproject.toml)
+joblib==1.5.3
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
 joinem==0.11.1
     # via phyloframe (../../pyproject.toml)
 lazy-loader==0.4
@@ -35,16 +39,26 @@ numpy==2.4.2
     #   fishersrc
     #   numba
     #   pandas
+    #   patsy
+    #   scikit-learn
     #   scipy
+    #   statsmodels
 opytional==0.1.0
+    # via phyloframe (../../pyproject.toml)
+ordered-set==4.1.0
     # via phyloframe (../../pyproject.toml)
 packaging==26.0
     # via
     #   lazy-loader
     #   pytest
+    #   statsmodels
     #   tox
 pandas==2.3.3
-    # via phyloframe (../../pyproject.toml)
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   statsmodels
+patsy==1.0.2
+    # via statsmodels
 platformdirs==4.9.2
     # via
     #   python-discovery
@@ -86,17 +100,30 @@ pytz==2025.2
     # via pandas
 safe-assert==0.2.0
     # via phyloframe (../../pyproject.toml)
-scipy==1.17.1
+scikit-learn==1.8.0
     # via phyloframe (../../pyproject.toml)
+scipy==1.17.1
+    # via
+    #   phyloframe (../../pyproject.toml)
+    #   scikit-learn
+    #   statsmodels
 setuptools==80.10.2
     # via phyloframe (../../pyproject.toml)
 six==1.17.0
     # via
     #   python-dateutil
     #   tox
+sortedcontainers==2.4.0
+    # via phyloframe (../../pyproject.toml)
+statsmodels==0.14.6
+    # via phyloframe (../../pyproject.toml)
+threadpoolctl==3.6.0
+    # via scikit-learn
 toml==0.10.2
     # via tox
 tox==3.24.0
+    # via phyloframe (../../pyproject.toml)
+tqdist==1.0
     # via phyloframe (../../pyproject.toml)
 tqdm==4.67.3
     # via


### PR DESCRIPTION
The refactor from hstrat dropped several packages from pyproject.toml that are still imported by the source code:

- joblib (parallel processing in legacy clade growth)
- ordered-set (legacy leaf ID finding)
- scikit-learn (legacy logistic growth classification)
- sortedcontainers (legacy MRCA and triplet categorization)
- statsmodels (auxlib binomial p estimation)
- tqdist (legacy triplet distance calculation)

Regenerate all requirements files for py310-py314.

https://claude.ai/code/session_01LVusTRu5bcTMNJD9rJETDG