### PR TITLE
Add Zenodo DOI and improve citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,9 +1,14 @@
-cff-version: 0.1.0
+cff-version: 1.1.0
 message: "If you use this software, please cite it as below."
+title: 'phyloframe: Dataframe-based tools for working with phylogenetic trees'
+abstract: "Dataframe-based tools for working with phylogenetic trees."
 authors:
-  - family-names: Moreno
-    given-names: Matthew Andres
-    orcid: https://orcid.org/0000-0003-4726-4479
-title: "phyloframe"
-version: 0.1.0
+- family-names: Moreno
+  given-names: Matthew Andres
+  orcid: 0000-0003-4726-4479
+date-released: 2026-03-03
+doi: 10.5281/zenodo.18842674
+license: MIT
+repository-code: https://github.com/mmore500/phyloframe
 url: "https://github.com/mmore500/phyloframe"
+version: 0.1.0

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ](https://codecov.io/gh/mmore500/phyloframe)
 [
 ![GitHub stars](https://img.shields.io/github/stars/mmore500/phyloframe.svg?style=round-square&logo=github&label=Stars&logoColor=white)](https://github.com/mmore500/phyloframe)
+[![DOI](https://zenodo.org/badge/1170914158.svg)](https://zenodo.org/doi/10.5281/zenodo.18842673)
 
 Dataframe-based tools for working with phylogenetic trees.
 
@@ -40,7 +41,21 @@ print(df)
 
 If phyloframe contributes to a scholarly work, please cite it as
 
-> Matthew Andres Moreno. phyloframe. <https://github.com/mmore500/phyloframe>
+> Matthew Andres Moreno. (2026). mmore500/phyloframe. Zenodo. https://doi.org/10.5281/zenodo.18842674
+
+```bibtex
+@software{moreno2026phyloframe,
+  author = {Matthew Andres Moreno},
+  title = {mmore500/phyloframe},
+  month = mar,
+  year = 2026,
+  publisher = {Zenodo},
+  doi = {10.5281/zenodo.18842674},
+  url = {https://doi.org/10.5281/zenodo.18842674}
+}
+```
+
+And don't forget to leave a [star on GitHub](https://github.com/mmore500/phyloframe/stargazers)!
 
 ## Author
 


### PR DESCRIPTION
## Summary
This PR updates the project's citation metadata and documentation to include a Zenodo DOI and provides improved citation formats for scholarly works.

## Key Changes
- **CITATION.cff**: Updated to CFF version 1.1.0 with comprehensive metadata
  - Added DOI: `10.5281/zenodo.18842674`
  - Added release date: 2026-03-03
  - Added license: MIT
  - Added repository code URL
  - Reformatted author ORCID to standard format (without URL prefix)
  - Added abstract field

- **README.md**: Enhanced citation guidance
  - Added Zenodo DOI badge linking to the release
  - Updated citation text to reference Zenodo DOI instead of GitHub URL
  - Added BibTeX citation format for academic references
  - Added call-to-action encouraging users to star the repository on GitHub

## Notable Details
These changes enable proper academic citation of the software through Zenodo while maintaining backward compatibility with the GitHub repository URL. The BibTeX format provides a standard way for researchers to cite this work in their publications.

https://claude.ai/code/session_01R4ZySZRNfv8vWkn3wbFVrh