### PR TITLE
Add Avida SPOP parser with pandas and polars implementations

### DIFF
--- a/phyloframe/legacy/__init__.pyi
+++ b/phyloframe/legacy/__init__.pyi
@@ -195,6 +195,8 @@ from ._alifestd_find_pair_mrca_id_polars import (
 )
 from ._alifestd_find_root_ids import alifestd_find_root_ids
 from ._alifestd_find_root_ids_polars import alifestd_find_root_ids_polars
+from ._alifestd_from_avida_spop import alifestd_from_avida_spop
+from ._alifestd_from_avida_spop_polars import alifestd_from_avida_spop_polars
 from ._alifestd_from_newick import alifestd_from_newick
 from ._alifestd_from_newick_polars import alifestd_from_newick_polars
 from ._alifestd_has_compact_ids import alifestd_has_compact_ids
@@ -730,6 +732,8 @@ __all__ = [
     "alifestd_find_pair_mrca_id_polars",
     "alifestd_find_root_ids",
     "alifestd_find_root_ids_polars",
+    "alifestd_from_avida_spop",
+    "alifestd_from_avida_spop_polars",
     "alifestd_from_newick",
     "alifestd_from_newick_polars",
     "alifestd_has_compact_ids",

--- a/phyloframe/legacy/_alifestd_from_avida_spop.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop.py
@@ -63,7 +63,7 @@ def _parse_spop_text(
     for line in spop_text.splitlines():
         stripped = line.strip()
         if not stripped or stripped[0] == "#":
-            if stripped.startswith("#format"):
+            if header is None and stripped.startswith("#format"):
                 header = _parse_spop_header(stripped)
             continue
         data_lines.append(stripped)

--- a/phyloframe/legacy/_alifestd_from_avida_spop.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop.py
@@ -6,40 +6,12 @@ import typing
 
 import numpy as np
 import pandas as pd
-import polars as pl
 
 from .._auxlib._configure_prod_logging import configure_prod_logging
 from .._auxlib._eval_kwargs import eval_kwargs
 from .._auxlib._format_cli_description import format_cli_description
 from .._auxlib._get_phyloframe_version import get_phyloframe_version
 from .._auxlib._log_context_duration import log_context_duration
-
-# Avida SPOP fields that contain comma-delimited sets.
-_AVIDA_SET_FIELDS = frozenset({"parents", "cells", "gest_offset", "lineage"})
-
-# Mapping from Avida field names to alife standard column names.
-_AVIDA_TO_ALIFE_FIELD = {
-    "id": "id",
-    "parents": "ancestor_list",
-    "update_born": "origin_time",
-    "src": "src",
-    "src_args": "src_args",
-    "num_units": "num_units",
-    "total_units": "total_units",
-    "length": "length",
-    "merit": "merit",
-    "gest_time": "gest_time",
-    "fitness": "fitness",
-    "gen_born": "gen_born",
-    "update_deactivated": "update_deactivated",
-    "depth": "depth",
-    "hw_type": "hw_type",
-    "inst_set": "inst_set",
-    "sequence": "sequence",
-    "cells": "cells",
-    "gest_offset": "gest_offset",
-    "lineage": "lineage",
-}
 
 
 def _parse_spop_header(line: str) -> typing.List[str]:
@@ -181,15 +153,10 @@ def alifestd_from_avida_spop(
         dtype=np.int64,
     )
 
-    # Add remaining Avida fields with standard names.
-    skip_avida = {"id", "parents", "update_born"}
-    for avida_field, alife_field in _AVIDA_TO_ALIFE_FIELD.items():
-        if (
-            avida_field in avida_data
-            and avida_field not in skip_avida
-            and alife_field not in result_data
-        ):
-            result_data[alife_field] = avida_data[avida_field]
+    # Add remaining Avida fields under their original names.
+    for field in header:
+        if field not in ("id", "parents", "update_born"):
+            result_data[field] = avida_data[field]
 
     return pd.DataFrame(result_data)
 
@@ -256,6 +223,8 @@ def _create_parser() -> argparse.ArgumentParser:
 
 
 if __name__ == "__main__":
+    import polars as pl
+
     configure_prod_logging()
 
     parser = _create_parser()

--- a/phyloframe/legacy/_alifestd_from_avida_spop.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop.py
@@ -71,9 +71,7 @@ def _parse_spop_text(
             "Failed to find #format header in spop text.",
         )
 
-    avida_data: typing.Dict[str, typing.List[str]] = {
-        field: [] for field in header
-    }
+    avida_data = {field: [] for field in header}
     for line in data_lines:
         parts = line.split(" ")
         for i, field in enumerate(header):

--- a/phyloframe/legacy/_alifestd_from_avida_spop.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop.py
@@ -7,6 +7,7 @@ import typing
 import numpy as np
 import pandas as pd
 
+from .._auxlib._add_bool_arg import add_bool_arg
 from .._auxlib._configure_prod_logging import configure_prod_logging
 from .._auxlib._eval_kwargs import eval_kwargs
 from .._auxlib._format_cli_description import format_cli_description
@@ -84,7 +85,7 @@ def _parse_spop_text(
             if required not in avida_data:
                 raise ValueError(
                     f"Required column {required!r} missing from "
-                    f"#format header.",
+                    "#format header.",
                 )
         if len(set(avida_data["id"])) != len(avida_data["id"]):
             raise ValueError("Avida organism IDs must be unique.")
@@ -197,11 +198,11 @@ def _create_parser() -> argparse.ArgumentParser:
         default="pandas",
         help="DataFrame engine to use for writing the output file. Defaults to 'pandas'.",
     )
-    parser.add_argument(
-        "--no-ancestor-list",
-        action="store_true",
-        default=False,
-        help="Exclude the ancestor_list column from the output.",
+    add_bool_arg(
+        parser,
+        "ancestor-list",
+        default=True,
+        help="Include an ancestor_list column in the output.",
     )
     parser.add_argument(
         "--output-kwarg",
@@ -243,7 +244,7 @@ if __name__ == "__main__":
         logging.info("converting from Avida .spop format...")
         phylogeny_df = alifestd_from_avida_spop(
             spop_str,
-            create_ancestor_list=not args.no_ancestor_list,
+            create_ancestor_list=args.ancestor_list,
         )
 
     output_ext = os.path.splitext(args.output_file)[1]

--- a/phyloframe/legacy/_alifestd_from_avida_spop.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop.py
@@ -32,37 +32,10 @@ _AVIDA_TO_ALIFE_FIELD = {
 
 
 def _parse_spop_header(line: str) -> typing.List[str]:
-    """Extract field names from the ``#format`` header line.
-
-    Parameters
-    ----------
-    line : str
-        A line beginning with ``#format``.
-
-    Returns
-    -------
-    list of str
-        Field names in order.
-    """
     return line.replace("#format", "").strip().split()
 
 
-def _parse_spop_ancestor_list(
-    raw_parents: str,
-) -> str:
-    """Convert Avida parents field to alife-standard ancestor_list string.
-
-    Parameters
-    ----------
-    raw_parents : str
-        Comma-delimited parent IDs, or ``"(none)"`` for the root.
-
-    Returns
-    -------
-    str
-        Alife-standard ancestor_list value, e.g. ``"[none]"`` or
-        ``"[123,456]"``.
-    """
+def _parse_spop_ancestor_list(raw_parents: str) -> str:
     if raw_parents == "(none)":
         return "[none]"
     return "[" + raw_parents + "]"
@@ -71,29 +44,6 @@ def _parse_spop_ancestor_list(
 def _parse_spop_text(
     spop_text: str,
 ) -> typing.Tuple[typing.List[str], typing.Dict[str, typing.List[str]]]:
-    """Parse raw spop text into a header and per-field string lists.
-
-    Implementation detail shared by ``alifestd_from_avida_spop`` and
-    ``alifestd_from_avida_spop_polars``.
-
-    Parameters
-    ----------
-    spop_text : str
-        Full text content of an Avida ``.spop`` file.
-
-    Returns
-    -------
-    tuple of (list[str], dict[str, list[str]])
-        ``(header, avida_data)`` where *header* is the ordered list of
-        field names and *avida_data* maps each field name to its list of
-        raw string values (one entry per data row).  Missing trailing
-        fields are filled with ``"NONE"``.
-
-    Raises
-    ------
-    ValueError
-        If the ``#format`` header line is missing from the spop text.
-    """
     header = None
     data_lines: typing.List[str] = []
 

--- a/phyloframe/legacy/_alifestd_from_avida_spop.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop.py
@@ -1,0 +1,159 @@
+import typing
+
+import numpy as np
+import pandas as pd
+
+# Avida SPOP fields that contain comma-delimited sets.
+_AVIDA_SET_FIELDS = frozenset({"parents", "cells", "gest_offset", "lineage"})
+
+# Mapping from Avida field names to alife standard column names.
+_AVIDA_TO_ALIFE_FIELD = {
+    "id": "id",
+    "parents": "ancestor_list",
+    "update_born": "origin_time",
+    "src": "src",
+    "src_args": "src_args",
+    "num_units": "num_units",
+    "total_units": "total_units",
+    "length": "length",
+    "merit": "merit",
+    "gest_time": "gest_time",
+    "fitness": "fitness",
+    "gen_born": "gen_born",
+    "update_deactivated": "update_deactivated",
+    "depth": "depth",
+    "hw_type": "hw_type",
+    "inst_set": "inst_set",
+    "sequence": "sequence",
+    "cells": "cells",
+    "gest_offset": "gest_offset",
+    "lineage": "lineage",
+}
+
+
+def _parse_spop_header(line: str) -> typing.List[str]:
+    """Extract field names from the ``#format`` header line.
+
+    Parameters
+    ----------
+    line : str
+        A line beginning with ``#format``.
+
+    Returns
+    -------
+    list of str
+        Field names in order.
+    """
+    return line.replace("#format", "").strip().split()
+
+
+def _parse_spop_ancestor_list(
+    raw_parents: str,
+) -> str:
+    """Convert Avida parents field to alife-standard ancestor_list string.
+
+    Parameters
+    ----------
+    raw_parents : str
+        Comma-delimited parent IDs, or ``"(none)"`` for the root.
+
+    Returns
+    -------
+    str
+        Alife-standard ancestor_list value, e.g. ``"[none]"`` or
+        ``"[123,456]"``.
+    """
+    if raw_parents == "(none)":
+        return "[none]"
+    return "[" + raw_parents + "]"
+
+
+def alifestd_from_avida_spop(
+    spop_text: str,
+    *,
+    create_ancestor_list: bool = True,
+) -> pd.DataFrame:
+    """Convert Avida ``.spop`` population snapshot text to a phylogeny
+    dataframe.
+
+    Parses the text content of an Avida ``.spop`` (structured population)
+    file and returns a pandas DataFrame in alife standard format.
+
+    Parameters
+    ----------
+    spop_text : str
+        Full text content of an Avida ``.spop`` file.
+    create_ancestor_list : bool, default True
+        If True, include an ``ancestor_list`` column in the result.
+
+    Returns
+    -------
+    pd.DataFrame
+        Phylogeny dataframe in alife standard format.
+
+    See Also
+    --------
+    alifestd_from_avida_spop_polars :
+        Polars-based implementation.
+
+    Raises
+    ------
+    ValueError
+        If the ``#format`` header is missing from the spop text.
+    """
+    header = None
+    data_lines = []
+
+    for line in spop_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped[0] == "#":
+            if stripped.startswith("#format"):
+                header = _parse_spop_header(stripped)
+            continue
+        data_lines.append(stripped)
+
+    if header is None:
+        raise ValueError(
+            "Failed to find #format header in spop text.",
+        )
+
+    if not data_lines:
+        columns = {"id": pd.Series(dtype=np.int64)}
+        if create_ancestor_list:
+            columns["ancestor_list"] = pd.Series(dtype=str)
+        columns["origin_time"] = pd.Series(dtype=np.int64)
+        return pd.DataFrame(columns)
+
+    # Parse data rows.
+    avida_data: typing.Dict[str, typing.List] = {field: [] for field in header}
+    for line in data_lines:
+        parts = line.split(" ")
+        for i, field in enumerate(header):
+            value = parts[i] if i < len(parts) else "NONE"
+            avida_data[field].append(value)
+
+    # Build alife-standard columns.
+    result_data: typing.Dict[str, typing.Any] = {}
+    result_data["id"] = pd.array(avida_data["id"], dtype=np.int64)
+
+    if create_ancestor_list:
+        result_data["ancestor_list"] = [
+            _parse_spop_ancestor_list(p) for p in avida_data["parents"]
+        ]
+
+    result_data["origin_time"] = pd.array(
+        avida_data["update_born"],
+        dtype=np.int64,
+    )
+
+    # Add remaining Avida fields with standard names.
+    skip_avida = {"id", "parents", "update_born"}
+    for avida_field, alife_field in _AVIDA_TO_ALIFE_FIELD.items():
+        if (
+            avida_field in avida_data
+            and avida_field not in skip_avida
+            and alife_field not in result_data
+        ):
+            result_data[alife_field] = avida_data[avida_field]
+
+    return pd.DataFrame(result_data)

--- a/phyloframe/legacy/_alifestd_from_avida_spop.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop.py
@@ -12,6 +12,7 @@ from .._auxlib._eval_kwargs import eval_kwargs
 from .._auxlib._format_cli_description import format_cli_description
 from .._auxlib._get_phyloframe_version import get_phyloframe_version
 from .._auxlib._log_context_duration import log_context_duration
+from ._alifestd_make_empty import alifestd_make_empty
 
 
 def _parse_spop_header(line: str) -> typing.List[str]:
@@ -85,7 +86,6 @@ def alifestd_from_avida_spop(
     spop_text: str,
     *,
     create_ancestor_list: bool = True,
-    dtype_id: typing.Optional[type] = np.int64,
 ) -> pd.DataFrame:
     """Convert Avida ``.spop`` population snapshot text to a phylogeny
     dataframe.
@@ -99,10 +99,6 @@ def alifestd_from_avida_spop(
         Full text content of an Avida ``.spop`` file.
     create_ancestor_list : bool, default True
         If True, include an ``ancestor_list`` column in the result.
-    dtype_id : type or None, default np.int64
-        Numpy dtype for the ``id`` column. If None, the smallest signed
-        integer dtype is chosen automatically based on the maximum id
-        value in the data.
 
     Returns
     -------
@@ -121,25 +117,12 @@ def alifestd_from_avida_spop(
     """
     header, avida_data = _parse_spop_text(spop_text)
 
-    if dtype_id is None:
-        if avida_data["id"]:
-            max_id = max(int(v) for v in avida_data["id"])
-            resolved_dtype_id = np.min_scalar_type(-max(max_id, 1))
-        else:
-            resolved_dtype_id = np.min_scalar_type(-1)
-    else:
-        resolved_dtype_id = np.dtype(dtype_id)
-
     if not avida_data["id"]:
-        columns = {"id": pd.Series(dtype=resolved_dtype_id)}
-        if create_ancestor_list:
-            columns["ancestor_list"] = pd.Series(dtype=str)
-        columns["origin_time"] = pd.Series(dtype=np.int64)
-        return pd.DataFrame(columns)
+        return alifestd_make_empty()
 
     # Build alife-standard columns.
-    result_data: typing.Dict[str, typing.Any] = {}
-    result_data["id"] = pd.array(avida_data["id"], dtype=resolved_dtype_id)
+    result_data = {}
+    result_data["id"] = pd.array(avida_data["id"], dtype=np.int64)
 
     if create_ancestor_list:
         result_data["ancestor_list"] = [

--- a/phyloframe/legacy/_alifestd_from_avida_spop.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop.py
@@ -68,6 +68,60 @@ def _parse_spop_ancestor_list(
     return "[" + raw_parents + "]"
 
 
+def _parse_spop_text(
+    spop_text: str,
+) -> typing.Tuple[typing.List[str], typing.Dict[str, typing.List[str]]]:
+    """Parse raw spop text into a header and per-field string lists.
+
+    Implementation detail shared by ``alifestd_from_avida_spop`` and
+    ``alifestd_from_avida_spop_polars``.
+
+    Parameters
+    ----------
+    spop_text : str
+        Full text content of an Avida ``.spop`` file.
+
+    Returns
+    -------
+    tuple of (list[str], dict[str, list[str]])
+        ``(header, avida_data)`` where *header* is the ordered list of
+        field names and *avida_data* maps each field name to its list of
+        raw string values (one entry per data row).  Missing trailing
+        fields are filled with ``"NONE"``.
+
+    Raises
+    ------
+    ValueError
+        If the ``#format`` header line is missing from the spop text.
+    """
+    header = None
+    data_lines: typing.List[str] = []
+
+    for line in spop_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped[0] == "#":
+            if stripped.startswith("#format"):
+                header = _parse_spop_header(stripped)
+            continue
+        data_lines.append(stripped)
+
+    if header is None:
+        raise ValueError(
+            "Failed to find #format header in spop text.",
+        )
+
+    avida_data: typing.Dict[str, typing.List[str]] = {
+        field: [] for field in header
+    }
+    for line in data_lines:
+        parts = line.split(" ")
+        for i, field in enumerate(header):
+            value = parts[i] if i < len(parts) else "NONE"
+            avida_data[field].append(value)
+
+    return header, avida_data
+
+
 def alifestd_from_avida_spop(
     spop_text: str,
     *,
@@ -101,36 +155,14 @@ def alifestd_from_avida_spop(
     ValueError
         If the ``#format`` header is missing from the spop text.
     """
-    header = None
-    data_lines = []
+    header, avida_data = _parse_spop_text(spop_text)
 
-    for line in spop_text.splitlines():
-        stripped = line.strip()
-        if not stripped or stripped[0] == "#":
-            if stripped.startswith("#format"):
-                header = _parse_spop_header(stripped)
-            continue
-        data_lines.append(stripped)
-
-    if header is None:
-        raise ValueError(
-            "Failed to find #format header in spop text.",
-        )
-
-    if not data_lines:
+    if not avida_data["id"]:
         columns = {"id": pd.Series(dtype=np.int64)}
         if create_ancestor_list:
             columns["ancestor_list"] = pd.Series(dtype=str)
         columns["origin_time"] = pd.Series(dtype=np.int64)
         return pd.DataFrame(columns)
-
-    # Parse data rows.
-    avida_data: typing.Dict[str, typing.List] = {field: [] for field in header}
-    for line in data_lines:
-        parts = line.split(" ")
-        for i, field in enumerate(header):
-            value = parts[i] if i < len(parts) else "NONE"
-            avida_data[field].append(value)
 
     # Build alife-standard columns.
     result_data: typing.Dict[str, typing.Any] = {}

--- a/phyloframe/legacy/_alifestd_from_avida_spop.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop.py
@@ -125,7 +125,8 @@ def _parse_spop_text(
 def alifestd_from_avida_spop(
     spop_text: str,
     *,
-    create_ancestor_list: bool = True,
+    create_ancestor_list: bool = False,
+    dtype_id: typing.Optional[type] = np.int64,
 ) -> pd.DataFrame:
     """Convert Avida ``.spop`` population snapshot text to a phylogeny
     dataframe.
@@ -137,8 +138,12 @@ def alifestd_from_avida_spop(
     ----------
     spop_text : str
         Full text content of an Avida ``.spop`` file.
-    create_ancestor_list : bool, default True
+    create_ancestor_list : bool, default False
         If True, include an ``ancestor_list`` column in the result.
+    dtype_id : type or None, default np.int64
+        Numpy dtype for the ``id`` column. If None, the smallest signed
+        integer dtype is chosen automatically based on the maximum id
+        value in the data.
 
     Returns
     -------
@@ -157,8 +162,17 @@ def alifestd_from_avida_spop(
     """
     header, avida_data = _parse_spop_text(spop_text)
 
+    if dtype_id is None:
+        if avida_data["id"]:
+            max_id = max(int(v) for v in avida_data["id"])
+            resolved_dtype_id = np.min_scalar_type(-max(max_id, 1))
+        else:
+            resolved_dtype_id = np.min_scalar_type(-1)
+    else:
+        resolved_dtype_id = np.dtype(dtype_id)
+
     if not avida_data["id"]:
-        columns = {"id": pd.Series(dtype=np.int64)}
+        columns = {"id": pd.Series(dtype=resolved_dtype_id)}
         if create_ancestor_list:
             columns["ancestor_list"] = pd.Series(dtype=str)
         columns["origin_time"] = pd.Series(dtype=np.int64)
@@ -166,7 +180,7 @@ def alifestd_from_avida_spop(
 
     # Build alife-standard columns.
     result_data: typing.Dict[str, typing.Any] = {}
-    result_data["id"] = pd.array(avida_data["id"], dtype=np.int64)
+    result_data["id"] = pd.array(avida_data["id"], dtype=resolved_dtype_id)
 
     if create_ancestor_list:
         result_data["ancestor_list"] = [

--- a/phyloframe/legacy/_alifestd_from_avida_spop.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop.py
@@ -62,6 +62,9 @@ def _parse_spop_text(
     Implementation detail shared by ``alifestd_from_avida_spop`` and
     ``alifestd_from_avida_spop_polars``.
 
+    Adapted from
+    https://github.com/alife-data-standards/converters-avida
+
     Parameters
     ----------
     spop_text : str

--- a/phyloframe/legacy/_alifestd_from_avida_spop.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop.py
@@ -123,7 +123,10 @@ def alifestd_from_avida_spop(
     header, avida_data = _parse_spop_text(spop_text)
 
     if len(avida_data["id"]) == 0:
-        return alifestd_make_empty()
+        df = alifestd_make_empty()
+        if not create_ancestor_list:
+            df = df.drop(columns=["ancestor_list"])
+        return df
 
     if dtype_id is None:
         row_count = len(avida_data["id"])

--- a/phyloframe/legacy/_alifestd_from_avida_spop.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop.py
@@ -79,6 +79,16 @@ def _parse_spop_text(
             value = parts[i] if i < len(parts) else "NONE"
             avida_data[field].append(value)
 
+    if data_lines:
+        for required in ("id", "parents"):
+            if required not in avida_data:
+                raise ValueError(
+                    f"Required column {required!r} missing from "
+                    f"#format header.",
+                )
+        if len(set(avida_data["id"])) != len(avida_data["id"]):
+            raise ValueError("Avida organism IDs must be unique.")
+
     return header, avida_data
 
 

--- a/phyloframe/legacy/_alifestd_from_avida_spop.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop.py
@@ -152,9 +152,8 @@ def alifestd_from_avida_spop(
     )
 
     # Add remaining Avida fields under their original names.
-    for field in header:
-        if field not in ("id", "parents", "update_born"):
-            result_data[field] = avida_data[field]
+    for field in set(header) - {"id", "parents", "update_born"}:
+        result_data[field] = avida_data[field]
 
     return pd.DataFrame(result_data)
 

--- a/phyloframe/legacy/_alifestd_from_avida_spop.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop.py
@@ -32,10 +32,12 @@ _AVIDA_TO_ALIFE_FIELD = {
 
 
 def _parse_spop_header(line: str) -> typing.List[str]:
+    """Extract field names from the ``#format`` header line."""
     return line.replace("#format", "").strip().split()
 
 
 def _parse_spop_ancestor_list(raw_parents: str) -> str:
+    """Convert Avida parents field to alife-standard ancestor_list string."""
     if raw_parents == "(none)":
         return "[none]"
     return "[" + raw_parents + "]"
@@ -44,6 +46,29 @@ def _parse_spop_ancestor_list(raw_parents: str) -> str:
 def _parse_spop_text(
     spop_text: str,
 ) -> typing.Tuple[typing.List[str], typing.Dict[str, typing.List[str]]]:
+    """Parse raw spop text into a header and per-field string lists.
+
+    Implementation detail shared by ``alifestd_from_avida_spop`` and
+    ``alifestd_from_avida_spop_polars``.
+
+    Parameters
+    ----------
+    spop_text : str
+        Full text content of an Avida ``.spop`` file.
+
+    Returns
+    -------
+    tuple of (list[str], dict[str, list[str]])
+        ``(header, avida_data)`` where *header* is the ordered list of
+        field names and *avida_data* maps each field name to its list of
+        raw string values (one entry per data row).  Missing trailing
+        fields are filled with ``"NONE"``.
+
+    Raises
+    ------
+    ValueError
+        If the ``#format`` header line is missing from the spop text.
+    """
     header = None
     data_lines: typing.List[str] = []
 

--- a/phyloframe/legacy/_alifestd_from_avida_spop.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop.py
@@ -86,6 +86,7 @@ def alifestd_from_avida_spop(
     spop_text: str,
     *,
     create_ancestor_list: bool = True,
+    dtype_id: typing.Optional[type] = np.int64,
 ) -> pd.DataFrame:
     """Convert Avida ``.spop`` population snapshot text to a phylogeny
     dataframe.
@@ -99,6 +100,10 @@ def alifestd_from_avida_spop(
         Full text content of an Avida ``.spop`` file.
     create_ancestor_list : bool, default True
         If True, include an ``ancestor_list`` column in the result.
+    dtype_id : type or None, default np.int64
+        Numpy dtype for the ``id`` column. If None, the smallest signed
+        integer dtype is chosen automatically based on the number of
+        rows in the data.
 
     Returns
     -------
@@ -117,12 +122,18 @@ def alifestd_from_avida_spop(
     """
     header, avida_data = _parse_spop_text(spop_text)
 
-    if not avida_data["id"]:
+    if len(avida_data["id"]) == 0:
         return alifestd_make_empty()
+
+    if dtype_id is None:
+        row_count = len(avida_data["id"])
+        resolved_dtype_id = np.min_scalar_type(-max(row_count, 1))
+    else:
+        resolved_dtype_id = np.dtype(dtype_id)
 
     # Build alife-standard columns.
     result_data = {}
-    result_data["id"] = pd.array(avida_data["id"], dtype=np.int64)
+    result_data["id"] = pd.array(avida_data["id"], dtype=resolved_dtype_id)
 
     if create_ancestor_list:
         result_data["ancestor_list"] = [

--- a/phyloframe/legacy/_alifestd_from_avida_spop.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop.py
@@ -1,7 +1,18 @@
+import argparse
+import logging
+import os
+import pathlib
 import typing
 
 import numpy as np
 import pandas as pd
+import polars as pl
+
+from .._auxlib._configure_prod_logging import configure_prod_logging
+from .._auxlib._eval_kwargs import eval_kwargs
+from .._auxlib._format_cli_description import format_cli_description
+from .._auxlib._get_phyloframe_version import get_phyloframe_version
+from .._auxlib._log_context_duration import log_context_duration
 
 # Avida SPOP fields that contain comma-delimited sets.
 _AVIDA_SET_FIELDS = frozenset({"parents", "cells", "gest_offset", "lineage"})
@@ -100,7 +111,7 @@ def _parse_spop_text(
 def alifestd_from_avida_spop(
     spop_text: str,
     *,
-    create_ancestor_list: bool = False,
+    create_ancestor_list: bool = True,
     dtype_id: typing.Optional[type] = np.int64,
 ) -> pd.DataFrame:
     """Convert Avida ``.spop`` population snapshot text to a phylogeny
@@ -113,7 +124,7 @@ def alifestd_from_avida_spop(
     ----------
     spop_text : str
         Full text content of an Avida ``.spop`` file.
-    create_ancestor_list : bool, default False
+    create_ancestor_list : bool, default True
         If True, include an ``ancestor_list`` column in the result.
     dtype_id : type or None, default np.int64
         Numpy dtype for the ``id`` column. If None, the smallest signed
@@ -178,3 +189,120 @@ def alifestd_from_avida_spop(
             result_data[alife_field] = avida_data[avida_field]
 
     return pd.DataFrame(result_data)
+
+
+_raw_description = f"""{os.path.basename(__file__)} | (phyloframe v{get_phyloframe_version()})
+
+Convert Avida .spop population snapshot data to Alife standard format.
+
+Note that this CLI entrypoint is experimental and may be subject to change.
+"""
+
+
+def _create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=format_cli_description(_raw_description),
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        "-i",
+        "--input-file",
+        type=str,
+        help="Avida .spop file to convert to Alife standard dataframe format.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-file",
+        type=str,
+        help="Path to write Alife standard dataframe output to.",
+    )
+    parser.add_argument(
+        "--output-engine",
+        type=str,
+        choices=["pandas", "polars"],
+        default="pandas",
+        help="DataFrame engine to use for writing the output file. Defaults to 'pandas'.",
+    )
+    parser.add_argument(
+        "--no-ancestor-list",
+        action="store_true",
+        default=False,
+        help="Exclude the ancestor_list column from the output.",
+    )
+    parser.add_argument(
+        "--output-kwarg",
+        action="append",
+        dest="output_kwargs",
+        type=str,
+        default=[],
+        help=(
+            "Additional keyword arguments to pass to output engine call. "
+            "Provide as 'key=value'. "
+            "Specify multiple kwargs by using this flag multiple times. "
+            "Arguments will be evaluated as Python expressions. "
+            "Example: 'index=False'"
+        ),
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=get_phyloframe_version(),
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    configure_prod_logging()
+
+    parser = _create_parser()
+    args = parser.parse_args()
+
+    logging.info(f"reading Avida .spop data from {args.input_file}...")
+    spop_str = pathlib.Path(args.input_file).read_text()
+
+    with log_context_duration(
+        "phyloframe.legacy.alifestd_from_avida_spop", logging.info
+    ):
+        logging.info("converting from Avida .spop format...")
+        phylogeny_df = alifestd_from_avida_spop(
+            spop_str,
+            create_ancestor_list=not args.no_ancestor_list,
+        )
+
+    output_ext = os.path.splitext(args.output_file)[1]
+    output_kwargs = eval_kwargs(args.output_kwargs)
+
+    logging.info(
+        f"writing alife-standard {output_ext} phylogeny data to "
+        f"{args.output_file}...",
+    )
+    if args.output_engine == "polars":
+        phylogeny_df = pl.from_pandas(phylogeny_df)
+        dispatch_writer = {
+            ".csv": pl.DataFrame.write_csv,
+            ".fea": pl.DataFrame.write_ipc,
+            ".feather": pl.DataFrame.write_ipc,
+            ".pqt": pl.DataFrame.write_parquet,
+            ".parquet": pl.DataFrame.write_parquet,
+        }
+    elif args.output_engine == "pandas":
+        if output_ext == ".csv":
+            output_kwargs.setdefault("index", False)
+        dispatch_writer = {
+            ".csv": pd.DataFrame.to_csv,
+            ".fea": pd.DataFrame.to_feather,
+            ".feather": pd.DataFrame.to_feather,
+            ".pqt": pd.DataFrame.to_parquet,
+            ".parquet": pd.DataFrame.to_parquet,
+        }
+    else:
+        raise ValueError(f"unsupported output engine: {args.output_engine!r}")
+
+    dispatch_writer[output_ext](
+        phylogeny_df,
+        args.output_file,
+        **output_kwargs,
+    )
+
+    logging.info("done!")

--- a/phyloframe/legacy/_alifestd_from_avida_spop_polars.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop_polars.py
@@ -51,7 +51,12 @@ def alifestd_from_avida_spop_polars(
     header, avida_data = _parse_spop_text(spop_text)
 
     if len(avida_data["id"]) == 0:
-        return alifestd_make_empty_polars()
+        df = alifestd_make_empty_polars()
+        if create_ancestor_list and "ancestor_list" not in df.columns:
+            df = df.with_columns(
+                pl.Series("ancestor_list", [], dtype=pl.Utf8),
+            )
+        return df
 
     if dtype_id is None:
         row_count = len(avida_data["id"])

--- a/phyloframe/legacy/_alifestd_from_avida_spop_polars.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop_polars.py
@@ -1,0 +1,108 @@
+import typing
+
+import polars as pl
+
+from ._alifestd_from_avida_spop import (
+    _AVIDA_TO_ALIFE_FIELD,
+    _parse_spop_ancestor_list,
+    _parse_spop_header,
+)
+
+# Avida SPOP fields that contain comma-delimited sets.
+_AVIDA_SET_FIELDS = frozenset({"parents", "cells", "gest_offset", "lineage"})
+
+
+def alifestd_from_avida_spop_polars(
+    spop_text: str,
+    *,
+    create_ancestor_list: bool = True,
+) -> pl.DataFrame:
+    """Convert Avida ``.spop`` population snapshot text to a phylogeny
+    dataframe.
+
+    Parses the text content of an Avida ``.spop`` (structured population)
+    file and returns a polars DataFrame in alife standard format.
+
+    Parameters
+    ----------
+    spop_text : str
+        Full text content of an Avida ``.spop`` file.
+    create_ancestor_list : bool, default True
+        If True, include an ``ancestor_list`` column in the result.
+
+    Returns
+    -------
+    pl.DataFrame
+        Phylogeny dataframe in alife standard format.
+
+    See Also
+    --------
+    alifestd_from_avida_spop :
+        Pandas-based implementation.
+
+    Raises
+    ------
+    ValueError
+        If the ``#format`` header is missing from the spop text.
+    """
+    header = None
+    data_lines: typing.List[str] = []
+
+    for line in spop_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped[0] == "#":
+            if stripped.startswith("#format"):
+                header = _parse_spop_header(stripped)
+            continue
+        data_lines.append(stripped)
+
+    if header is None:
+        raise ValueError(
+            "Failed to find #format header in spop text.",
+        )
+
+    if not data_lines:
+        columns = {"id": pl.Series([], dtype=pl.Int64)}
+        if create_ancestor_list:
+            columns["ancestor_list"] = pl.Series([], dtype=pl.Utf8)
+        columns["origin_time"] = pl.Series([], dtype=pl.Int64)
+        return pl.DataFrame(columns)
+
+    # Parse data rows.
+    avida_data: typing.Dict[str, typing.List[str]] = {
+        field: [] for field in header
+    }
+    for line in data_lines:
+        parts = line.split(" ")
+        for i, field in enumerate(header):
+            value = parts[i] if i < len(parts) else "NONE"
+            avida_data[field].append(value)
+
+    # Build alife-standard columns.
+    result_data: typing.Dict[str, typing.Any] = {}
+    result_data["id"] = pl.Series(avida_data["id"]).cast(pl.Int64)
+
+    if create_ancestor_list:
+        result_data["ancestor_list"] = pl.Series(
+            [_parse_spop_ancestor_list(p) for p in avida_data["parents"]],
+            dtype=pl.Utf8,
+        )
+
+    result_data["origin_time"] = pl.Series(
+        avida_data["update_born"],
+    ).cast(pl.Int64)
+
+    # Add remaining Avida fields with standard names.
+    skip_avida = {"id", "parents", "update_born"}
+    for avida_field, alife_field in _AVIDA_TO_ALIFE_FIELD.items():
+        if (
+            avida_field in avida_data
+            and avida_field not in skip_avida
+            and alife_field not in result_data
+        ):
+            result_data[alife_field] = pl.Series(
+                avida_data[avida_field],
+                dtype=pl.Utf8,
+            )
+
+    return pl.DataFrame(result_data)

--- a/phyloframe/legacy/_alifestd_from_avida_spop_polars.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop_polars.py
@@ -4,7 +4,6 @@ import polars as pl
 
 from .._auxlib._min_scalar_type_polars import min_scalar_type_polars
 from ._alifestd_from_avida_spop import (
-    _AVIDA_TO_ALIFE_FIELD,
     _parse_spop_ancestor_list,
     _parse_spop_text,
 )
@@ -80,16 +79,11 @@ def alifestd_from_avida_spop_polars(
         avida_data["update_born"],
     ).cast(pl.Int64)
 
-    # Add remaining Avida fields with standard names.
-    skip_avida = {"id", "parents", "update_born"}
-    for avida_field, alife_field in _AVIDA_TO_ALIFE_FIELD.items():
-        if (
-            avida_field in avida_data
-            and avida_field not in skip_avida
-            and alife_field not in result_data
-        ):
-            result_data[alife_field] = pl.Series(
-                avida_data[avida_field],
+    # Add remaining Avida fields under their original names.
+    for field in header:
+        if field not in ("id", "parents", "update_born"):
+            result_data[field] = pl.Series(
+                avida_data[field],
                 dtype=pl.Utf8,
             )
 

--- a/phyloframe/legacy/_alifestd_from_avida_spop_polars.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop_polars.py
@@ -13,7 +13,7 @@ from ._alifestd_from_avida_spop import (
 def alifestd_from_avida_spop_polars(
     spop_text: str,
     *,
-    create_ancestor_list: bool = False,
+    create_ancestor_list: bool = True,
     dtype_id: typing.Optional[pl.datatypes.DataType] = pl.Int64,
 ) -> pl.DataFrame:
     """Convert Avida ``.spop`` population snapshot text to a phylogeny
@@ -26,7 +26,7 @@ def alifestd_from_avida_spop_polars(
     ----------
     spop_text : str
         Full text content of an Avida ``.spop`` file.
-    create_ancestor_list : bool, default False
+    create_ancestor_list : bool, default True
         If True, include an ``ancestor_list`` column in the result.
     dtype_id : pl.DataType or None, default pl.Int64
         Polars dtype for the ``id`` column. If None, the smallest signed

--- a/phyloframe/legacy/_alifestd_from_avida_spop_polars.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop_polars.py
@@ -1,19 +1,16 @@
-import typing
-
 import polars as pl
 
-from .._auxlib._min_scalar_type_polars import min_scalar_type_polars
 from ._alifestd_from_avida_spop import (
     _parse_spop_ancestor_list,
     _parse_spop_text,
 )
+from ._alifestd_make_empty_polars import alifestd_make_empty_polars
 
 
 def alifestd_from_avida_spop_polars(
     spop_text: str,
     *,
     create_ancestor_list: bool = True,
-    dtype_id: typing.Optional[pl.datatypes.DataType] = pl.Int64,
 ) -> pl.DataFrame:
     """Convert Avida ``.spop`` population snapshot text to a phylogeny
     dataframe.
@@ -27,10 +24,6 @@ def alifestd_from_avida_spop_polars(
         Full text content of an Avida ``.spop`` file.
     create_ancestor_list : bool, default True
         If True, include an ``ancestor_list`` column in the result.
-    dtype_id : pl.DataType or None, default pl.Int64
-        Polars dtype for the ``id`` column. If None, the smallest signed
-        integer dtype is chosen automatically based on the maximum id
-        value in the data.
 
     Returns
     -------
@@ -49,25 +42,12 @@ def alifestd_from_avida_spop_polars(
     """
     header, avida_data = _parse_spop_text(spop_text)
 
-    if dtype_id is None:
-        if avida_data["id"]:
-            max_id = max(int(v) for v in avida_data["id"])
-            pl_dtype_id = min_scalar_type_polars(-max(max_id, 1))
-        else:
-            pl_dtype_id = min_scalar_type_polars(-1)
-    else:
-        pl_dtype_id = dtype_id
-
     if not avida_data["id"]:
-        columns = {"id": pl.Series([], dtype=pl_dtype_id)}
-        if create_ancestor_list:
-            columns["ancestor_list"] = pl.Series([], dtype=pl.Utf8)
-        columns["origin_time"] = pl.Series([], dtype=pl.Int64)
-        return pl.DataFrame(columns)
+        return alifestd_make_empty_polars()
 
     # Build alife-standard columns.
     result_data = {}
-    result_data["id"] = pl.Series(avida_data["id"]).cast(pl_dtype_id)
+    result_data["id"] = pl.Series(avida_data["id"]).cast(pl.Int64)
 
     if create_ancestor_list:
         result_data["ancestor_list"] = pl.Series(

--- a/phyloframe/legacy/_alifestd_from_avida_spop_polars.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop_polars.py
@@ -80,11 +80,10 @@ def alifestd_from_avida_spop_polars(
     ).cast(pl.Int64)
 
     # Add remaining Avida fields under their original names.
-    for field in header:
-        if field not in ("id", "parents", "update_born"):
-            result_data[field] = pl.Series(
-                avida_data[field],
-                dtype=pl.Utf8,
-            )
+    for field in set(header) - {"id", "parents", "update_born"}:
+        result_data[field] = pl.Series(
+            avida_data[field],
+            dtype=pl.Utf8,
+        )
 
     return pl.DataFrame(result_data)

--- a/phyloframe/legacy/_alifestd_from_avida_spop_polars.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop_polars.py
@@ -1,15 +1,10 @@
-import typing
-
 import polars as pl
 
 from ._alifestd_from_avida_spop import (
     _AVIDA_TO_ALIFE_FIELD,
     _parse_spop_ancestor_list,
-    _parse_spop_header,
+    _parse_spop_text,
 )
-
-# Avida SPOP fields that contain comma-delimited sets.
-_AVIDA_SET_FIELDS = frozenset({"parents", "cells", "gest_offset", "lineage"})
 
 
 def alifestd_from_avida_spop_polars(
@@ -45,41 +40,17 @@ def alifestd_from_avida_spop_polars(
     ValueError
         If the ``#format`` header is missing from the spop text.
     """
-    header = None
-    data_lines: typing.List[str] = []
+    header, avida_data = _parse_spop_text(spop_text)
 
-    for line in spop_text.splitlines():
-        stripped = line.strip()
-        if not stripped or stripped[0] == "#":
-            if stripped.startswith("#format"):
-                header = _parse_spop_header(stripped)
-            continue
-        data_lines.append(stripped)
-
-    if header is None:
-        raise ValueError(
-            "Failed to find #format header in spop text.",
-        )
-
-    if not data_lines:
+    if not avida_data["id"]:
         columns = {"id": pl.Series([], dtype=pl.Int64)}
         if create_ancestor_list:
             columns["ancestor_list"] = pl.Series([], dtype=pl.Utf8)
         columns["origin_time"] = pl.Series([], dtype=pl.Int64)
         return pl.DataFrame(columns)
 
-    # Parse data rows.
-    avida_data: typing.Dict[str, typing.List[str]] = {
-        field: [] for field in header
-    }
-    for line in data_lines:
-        parts = line.split(" ")
-        for i, field in enumerate(header):
-            value = parts[i] if i < len(parts) else "NONE"
-            avida_data[field].append(value)
-
     # Build alife-standard columns.
-    result_data: typing.Dict[str, typing.Any] = {}
+    result_data = {}
     result_data["id"] = pl.Series(avida_data["id"]).cast(pl.Int64)
 
     if create_ancestor_list:

--- a/phyloframe/legacy/_alifestd_from_avida_spop_polars.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop_polars.py
@@ -1,5 +1,8 @@
+import typing
+
 import polars as pl
 
+from .._auxlib._min_scalar_type_polars import min_scalar_type_polars
 from ._alifestd_from_avida_spop import (
     _parse_spop_ancestor_list,
     _parse_spop_text,
@@ -11,6 +14,7 @@ def alifestd_from_avida_spop_polars(
     spop_text: str,
     *,
     create_ancestor_list: bool = True,
+    dtype_id: typing.Optional[pl.datatypes.DataType] = pl.Int64,
 ) -> pl.DataFrame:
     """Convert Avida ``.spop`` population snapshot text to a phylogeny
     dataframe.
@@ -24,6 +28,10 @@ def alifestd_from_avida_spop_polars(
         Full text content of an Avida ``.spop`` file.
     create_ancestor_list : bool, default True
         If True, include an ``ancestor_list`` column in the result.
+    dtype_id : pl.DataType or None, default pl.Int64
+        Polars dtype for the ``id`` column. If None, the smallest signed
+        integer dtype is chosen automatically based on the number of
+        rows in the data.
 
     Returns
     -------
@@ -42,12 +50,18 @@ def alifestd_from_avida_spop_polars(
     """
     header, avida_data = _parse_spop_text(spop_text)
 
-    if not avida_data["id"]:
+    if len(avida_data["id"]) == 0:
         return alifestd_make_empty_polars()
+
+    if dtype_id is None:
+        row_count = len(avida_data["id"])
+        pl_dtype_id = min_scalar_type_polars(-max(row_count, 1))
+    else:
+        pl_dtype_id = dtype_id
 
     # Build alife-standard columns.
     result_data = {}
-    result_data["id"] = pl.Series(avida_data["id"]).cast(pl.Int64)
+    result_data["id"] = pl.Series(avida_data["id"]).cast(pl_dtype_id)
 
     if create_ancestor_list:
         result_data["ancestor_list"] = pl.Series(

--- a/phyloframe/legacy/_alifestd_from_avida_spop_polars.py
+++ b/phyloframe/legacy/_alifestd_from_avida_spop_polars.py
@@ -1,5 +1,8 @@
+import typing
+
 import polars as pl
 
+from .._auxlib._min_scalar_type_polars import min_scalar_type_polars
 from ._alifestd_from_avida_spop import (
     _AVIDA_TO_ALIFE_FIELD,
     _parse_spop_ancestor_list,
@@ -10,7 +13,8 @@ from ._alifestd_from_avida_spop import (
 def alifestd_from_avida_spop_polars(
     spop_text: str,
     *,
-    create_ancestor_list: bool = True,
+    create_ancestor_list: bool = False,
+    dtype_id: typing.Optional[pl.datatypes.DataType] = pl.Int64,
 ) -> pl.DataFrame:
     """Convert Avida ``.spop`` population snapshot text to a phylogeny
     dataframe.
@@ -22,8 +26,12 @@ def alifestd_from_avida_spop_polars(
     ----------
     spop_text : str
         Full text content of an Avida ``.spop`` file.
-    create_ancestor_list : bool, default True
+    create_ancestor_list : bool, default False
         If True, include an ``ancestor_list`` column in the result.
+    dtype_id : pl.DataType or None, default pl.Int64
+        Polars dtype for the ``id`` column. If None, the smallest signed
+        integer dtype is chosen automatically based on the maximum id
+        value in the data.
 
     Returns
     -------
@@ -42,8 +50,17 @@ def alifestd_from_avida_spop_polars(
     """
     header, avida_data = _parse_spop_text(spop_text)
 
+    if dtype_id is None:
+        if avida_data["id"]:
+            max_id = max(int(v) for v in avida_data["id"])
+            pl_dtype_id = min_scalar_type_polars(-max(max_id, 1))
+        else:
+            pl_dtype_id = min_scalar_type_polars(-1)
+    else:
+        pl_dtype_id = dtype_id
+
     if not avida_data["id"]:
-        columns = {"id": pl.Series([], dtype=pl.Int64)}
+        columns = {"id": pl.Series([], dtype=pl_dtype_id)}
         if create_ancestor_list:
             columns["ancestor_list"] = pl.Series([], dtype=pl.Utf8)
         columns["origin_time"] = pl.Series([], dtype=pl.Int64)
@@ -51,7 +68,7 @@ def alifestd_from_avida_spop_polars(
 
     # Build alife-standard columns.
     result_data = {}
-    result_data["id"] = pl.Series(avida_data["id"]).cast(pl.Int64)
+    result_data["id"] = pl.Series(avida_data["id"]).cast(pl_dtype_id)
 
     if create_ancestor_list:
         result_data["ancestor_list"] = pl.Series(

--- a/phyloframe/legacy/_alifestd_from_newick.py
+++ b/phyloframe/legacy/_alifestd_from_newick.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import polars as pl
 
+from .._auxlib._add_bool_arg import add_bool_arg
 from .._auxlib._configure_prod_logging import configure_prod_logging
 from .._auxlib._eval_kwargs import eval_kwargs
 from .._auxlib._format_cli_description import format_cli_description
@@ -506,9 +507,9 @@ def _create_parser() -> argparse.ArgumentParser:
         default="float",
         help="Dtype for branch length values. Defaults to 'float'.",
     )
-    parser.add_argument(
-        "--create-ancestor-list",
-        action="store_true",
+    add_bool_arg(
+        parser,
+        "create-ancestor-list",
         default=False,
         help="Include an ancestor_list column in the output.",
     )

--- a/phyloframe/legacy/_alifestd_from_newick_polars.py
+++ b/phyloframe/legacy/_alifestd_from_newick_polars.py
@@ -8,6 +8,7 @@ import numpy as np
 import polars as pl
 import pyarrow as pa
 
+from .._auxlib._add_bool_arg import add_bool_arg
 from .._auxlib._configure_prod_logging import configure_prod_logging
 from .._auxlib._eval_kwargs import eval_kwargs
 from .._auxlib._find_equivalent_numpy_dtype_polars import (
@@ -196,9 +197,9 @@ def _create_parser() -> argparse.ArgumentParser:
         default="float",
         help="Dtype for branch length values. Defaults to 'float'.",
     )
-    parser.add_argument(
-        "--create-ancestor-list",
-        action="store_true",
+    add_bool_arg(
+        parser,
+        "create-ancestor-list",
         default=False,
         help="Include an ancestor_list column in the output.",
     )

--- a/tests/test_phyloframe/test_legacy/assets/example-avida-asexual.spop
+++ b/tests/test_phyloframe/test_legacy/assets/example-avida-asexual.spop
@@ -1,0 +1,11 @@
+#filetype genotype_data
+#format id src src_args parents num_units total_units length merit gest_time fitness gen_born update_born update_deactivated depth hw_type inst_set sequence cells gest_offset lineage
+# Structured Population Save
+# Test fixture for asexual population
+#  1: ID
+#  2: Source
+1 org:file (none) (none) 1 1 100 100 100 1 0 0 -1 0 0 heads_default aaabbbccc 0 0 0
+2 div:int (none) 1 1 1 100 200 200 1 1 100 -1 1 0 heads_default aaabbbccd 1 100 0
+3 div:int (none) 1 1 1 100 200 200 1 1 200 -1 1 0 heads_default aaabbbcce 2 200 0
+4 div:int (none) 2 1 1 100 200 200 1 2 300 -1 2 0 heads_default aaabbbddd 3 300 0
+5 div:int (none) 2 1 1 100 200 200 1 2 400 -1 2 0 heads_default aaabbbeee 4 400 0

--- a/tests/test_phyloframe/test_legacy/assets/example-avida-sexual.spop
+++ b/tests/test_phyloframe/test_legacy/assets/example-avida-sexual.spop
@@ -1,0 +1,10 @@
+#filetype genotype_data
+#format id src src_args parents num_units total_units length merit gest_time fitness gen_born update_born update_deactivated depth hw_type inst_set sequence cells gest_offset lineage
+# Structured Population Save
+# Test fixture for sexual population
+#  1: ID
+#  2: Source
+100 org:file (none) (none) 1 1 100 100 100 1 0 0 -1 0 0 heads_default aaabbbccc 0 0 0
+200 org:file (none) (none) 1 1 100 100 100 1 0 0 -1 0 0 heads_default dddeeefff 1 0 0
+300 div:sex (none) 100,200 1 1 100 200 200 1 1 100 -1 1 0 heads_default aaaeeefff 2 100 0
+400 div:sex (none) 100,300 1 1 100 200 200 1 2 200 -1 2 0 heads_default aaabbbfff 3 200 0

--- a/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop.py
@@ -20,16 +20,6 @@ def test_empty_data():
     assert len(result) == 0
     assert "id" in result.columns
     assert "ancestor_list" in result.columns
-    assert "origin_time" in result.columns
-
-
-def test_empty_data_no_ancestor_list():
-    spop = "#filetype genotype_data\n#format id src parents update_born\n"
-    result = alifestd_from_avida_spop(spop, create_ancestor_list=False)
-    assert len(result) == 0
-    assert "id" in result.columns
-    assert "ancestor_list" not in result.columns
-    assert "origin_time" in result.columns
 
 
 def test_missing_header():
@@ -201,36 +191,3 @@ def test_returns_dataframe():
     spop = _read_asset("example-avida-asexual.spop")
     result = alifestd_from_avida_spop(spop)
     assert isinstance(result, pd.DataFrame)
-
-
-def test_dtype_id_default():
-    spop = _read_asset("example-avida-asexual.spop")
-    result = alifestd_from_avida_spop(spop)
-    assert result["id"].dtype == np.int64
-
-
-def test_dtype_id_int32():
-    spop = _read_asset("example-avida-asexual.spop")
-    result = alifestd_from_avida_spop(spop, dtype_id=np.int32)
-    assert result["id"].dtype == np.int32
-
-
-def test_dtype_id_none_small():
-    spop = (
-        "#filetype genotype_data\n"
-        "#format id src parents update_born\n"
-        "1 org:file (none) 0\n"
-        "2 div:int 1 100\n"
-    )
-    result = alifestd_from_avida_spop(spop, dtype_id=None)
-    # max id 2 -> min_scalar_type(-2) -> int8
-    assert result["id"].dtype == np.int8
-    assert len(result) == 2
-
-
-def test_dtype_id_none_empty():
-    spop = "#filetype genotype_data\n#format id src parents update_born\n"
-    result = alifestd_from_avida_spop(spop, dtype_id=None)
-    # no data -> min_scalar_type(-1) -> int8
-    assert result["id"].dtype == np.int8
-    assert len(result) == 0

--- a/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop.py
@@ -19,16 +19,16 @@ def test_empty_data():
     result = alifestd_from_avida_spop(spop)
     assert len(result) == 0
     assert "id" in result.columns
-    assert "ancestor_list" not in result.columns
+    assert "ancestor_list" in result.columns
     assert "origin_time" in result.columns
 
 
-def test_empty_data_with_ancestor_list():
+def test_empty_data_no_ancestor_list():
     spop = "#filetype genotype_data\n#format id src parents update_born\n"
-    result = alifestd_from_avida_spop(spop, create_ancestor_list=True)
+    result = alifestd_from_avida_spop(spop, create_ancestor_list=False)
     assert len(result) == 0
     assert "id" in result.columns
-    assert "ancestor_list" in result.columns
+    assert "ancestor_list" not in result.columns
     assert "origin_time" in result.columns
 
 
@@ -44,7 +44,7 @@ def test_single_root_organism():
         "#format id src parents update_born\n"
         "1 org:file (none) 0\n"
     )
-    result = alifestd_from_avida_spop(spop, create_ancestor_list=True)
+    result = alifestd_from_avida_spop(spop)
     assert len(result) == 1
     assert result["id"].iloc[0] == 1
     assert result["ancestor_list"].iloc[0] == "[none]"
@@ -58,7 +58,7 @@ def test_asexual_parent_child():
         "1 org:file (none) 0\n"
         "2 div:int 1 100\n"
     )
-    result = alifestd_from_avida_spop(spop, create_ancestor_list=True)
+    result = alifestd_from_avida_spop(spop)
     assert len(result) == 2
     assert result["ancestor_list"].iloc[0] == "[none]"
     assert result["ancestor_list"].iloc[1] == "[1]"
@@ -72,7 +72,7 @@ def test_sexual_parents():
         "200 org:file (none) 0\n"
         "300 div:sex 100,200 100\n"
     )
-    result = alifestd_from_avida_spop(spop, create_ancestor_list=True)
+    result = alifestd_from_avida_spop(spop)
     assert len(result) == 3
     assert result["ancestor_list"].iloc[0] == "[none]"
     assert result["ancestor_list"].iloc[1] == "[none]"
@@ -81,7 +81,7 @@ def test_sexual_parents():
 
 def test_asexual_asset():
     spop = _read_asset("example-avida-asexual.spop")
-    result = alifestd_from_avida_spop(spop, create_ancestor_list=True)
+    result = alifestd_from_avida_spop(spop)
 
     assert len(result) == 5
     assert "id" in result.columns
@@ -107,7 +107,7 @@ def test_asexual_asset():
 
 def test_sexual_asset():
     spop = _read_asset("example-avida-sexual.spop")
-    result = alifestd_from_avida_spop(spop, create_ancestor_list=True)
+    result = alifestd_from_avida_spop(spop)
 
     assert len(result) == 4
 
@@ -138,7 +138,7 @@ def test_extra_columns_preserved():
 
 def test_no_ancestor_list():
     spop = _read_asset("example-avida-asexual.spop")
-    result = alifestd_from_avida_spop(spop)
+    result = alifestd_from_avida_spop(spop, create_ancestor_list=False)
     assert "ancestor_list" not in result.columns
     assert "id" in result.columns
     assert "origin_time" in result.columns
@@ -176,7 +176,7 @@ def test_missing_trailing_fields():
 
 def test_column_order():
     spop = _read_asset("example-avida-asexual.spop")
-    result = alifestd_from_avida_spop(spop, create_ancestor_list=True)
+    result = alifestd_from_avida_spop(spop)
 
     cols = list(result.columns)
     # id, ancestor_list, and origin_time should be the first three

--- a/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop.py
@@ -19,16 +19,16 @@ def test_empty_data():
     result = alifestd_from_avida_spop(spop)
     assert len(result) == 0
     assert "id" in result.columns
-    assert "ancestor_list" in result.columns
+    assert "ancestor_list" not in result.columns
     assert "origin_time" in result.columns
 
 
-def test_empty_data_no_ancestor_list():
+def test_empty_data_with_ancestor_list():
     spop = "#filetype genotype_data\n#format id src parents update_born\n"
-    result = alifestd_from_avida_spop(spop, create_ancestor_list=False)
+    result = alifestd_from_avida_spop(spop, create_ancestor_list=True)
     assert len(result) == 0
     assert "id" in result.columns
-    assert "ancestor_list" not in result.columns
+    assert "ancestor_list" in result.columns
     assert "origin_time" in result.columns
 
 
@@ -44,7 +44,7 @@ def test_single_root_organism():
         "#format id src parents update_born\n"
         "1 org:file (none) 0\n"
     )
-    result = alifestd_from_avida_spop(spop)
+    result = alifestd_from_avida_spop(spop, create_ancestor_list=True)
     assert len(result) == 1
     assert result["id"].iloc[0] == 1
     assert result["ancestor_list"].iloc[0] == "[none]"
@@ -58,7 +58,7 @@ def test_asexual_parent_child():
         "1 org:file (none) 0\n"
         "2 div:int 1 100\n"
     )
-    result = alifestd_from_avida_spop(spop)
+    result = alifestd_from_avida_spop(spop, create_ancestor_list=True)
     assert len(result) == 2
     assert result["ancestor_list"].iloc[0] == "[none]"
     assert result["ancestor_list"].iloc[1] == "[1]"
@@ -72,7 +72,7 @@ def test_sexual_parents():
         "200 org:file (none) 0\n"
         "300 div:sex 100,200 100\n"
     )
-    result = alifestd_from_avida_spop(spop)
+    result = alifestd_from_avida_spop(spop, create_ancestor_list=True)
     assert len(result) == 3
     assert result["ancestor_list"].iloc[0] == "[none]"
     assert result["ancestor_list"].iloc[1] == "[none]"
@@ -81,7 +81,7 @@ def test_sexual_parents():
 
 def test_asexual_asset():
     spop = _read_asset("example-avida-asexual.spop")
-    result = alifestd_from_avida_spop(spop)
+    result = alifestd_from_avida_spop(spop, create_ancestor_list=True)
 
     assert len(result) == 5
     assert "id" in result.columns
@@ -107,7 +107,7 @@ def test_asexual_asset():
 
 def test_sexual_asset():
     spop = _read_asset("example-avida-sexual.spop")
-    result = alifestd_from_avida_spop(spop)
+    result = alifestd_from_avida_spop(spop, create_ancestor_list=True)
 
     assert len(result) == 4
 
@@ -138,7 +138,7 @@ def test_extra_columns_preserved():
 
 def test_no_ancestor_list():
     spop = _read_asset("example-avida-asexual.spop")
-    result = alifestd_from_avida_spop(spop, create_ancestor_list=False)
+    result = alifestd_from_avida_spop(spop)
     assert "ancestor_list" not in result.columns
     assert "id" in result.columns
     assert "origin_time" in result.columns
@@ -176,7 +176,7 @@ def test_missing_trailing_fields():
 
 def test_column_order():
     spop = _read_asset("example-avida-asexual.spop")
-    result = alifestd_from_avida_spop(spop)
+    result = alifestd_from_avida_spop(spop, create_ancestor_list=True)
 
     cols = list(result.columns)
     # id, ancestor_list, and origin_time should be the first three
@@ -201,3 +201,36 @@ def test_returns_dataframe():
     spop = _read_asset("example-avida-asexual.spop")
     result = alifestd_from_avida_spop(spop)
     assert isinstance(result, pd.DataFrame)
+
+
+def test_dtype_id_default():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop(spop)
+    assert result["id"].dtype == np.int64
+
+
+def test_dtype_id_int32():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop(spop, dtype_id=np.int32)
+    assert result["id"].dtype == np.int32
+
+
+def test_dtype_id_none_small():
+    spop = (
+        "#filetype genotype_data\n"
+        "#format id src parents update_born\n"
+        "1 org:file (none) 0\n"
+        "2 div:int 1 100\n"
+    )
+    result = alifestd_from_avida_spop(spop, dtype_id=None)
+    # max id 2 -> min_scalar_type(-2) -> int8
+    assert result["id"].dtype == np.int8
+    assert len(result) == 2
+
+
+def test_dtype_id_none_empty():
+    spop = "#filetype genotype_data\n#format id src parents update_born\n"
+    result = alifestd_from_avida_spop(spop, dtype_id=None)
+    # no data -> min_scalar_type(-1) -> int8
+    assert result["id"].dtype == np.int8
+    assert len(result) == 0

--- a/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop.py
@@ -42,6 +42,21 @@ def test_missing_required_column():
         alifestd_from_avida_spop(spop)
 
 
+def test_only_first_format_header_used():
+    # Second #format line should be ignored; first one (with 4 fields) wins.
+    spop = (
+        "#filetype genotype_data\n"
+        "#format id src parents update_born\n"
+        "#format id src\n"
+        "1 org:file (none) 0\n"
+    )
+    result = alifestd_from_avida_spop(spop)
+    assert len(result) == 1
+    assert result["id"].iloc[0] == 1
+    assert result["ancestor_list"].iloc[0] == "[none]"
+    assert result["origin_time"].iloc[0] == 0
+
+
 def test_duplicate_ids():
     spop = (
         "#filetype genotype_data\n"

--- a/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop.py
@@ -191,3 +191,28 @@ def test_returns_dataframe():
     spop = _read_asset("example-avida-asexual.spop")
     result = alifestd_from_avida_spop(spop)
     assert isinstance(result, pd.DataFrame)
+
+
+def test_dtype_id_default():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop(spop)
+    assert result["id"].dtype == np.int64
+
+
+def test_dtype_id_int32():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop(spop, dtype_id=np.int32)
+    assert result["id"].dtype == np.int32
+
+
+def test_dtype_id_none_small():
+    spop = (
+        "#filetype genotype_data\n"
+        "#format id src parents update_born\n"
+        "1 org:file (none) 0\n"
+        "2 div:int 1 100\n"
+    )
+    result = alifestd_from_avida_spop(spop, dtype_id=None)
+    # 2 rows -> min_scalar_type(-2) -> int8
+    assert result["id"].dtype == np.int8
+    assert len(result) == 2

--- a/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop.py
@@ -1,0 +1,203 @@
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from phyloframe.legacy import alifestd_from_avida_spop
+
+assets_path = os.path.join(os.path.dirname(__file__), "assets")
+
+
+def _read_asset(name: str) -> str:
+    with open(os.path.join(assets_path, name)) as f:
+        return f.read()
+
+
+def test_empty_data():
+    spop = "#filetype genotype_data\n#format id src parents update_born\n"
+    result = alifestd_from_avida_spop(spop)
+    assert len(result) == 0
+    assert "id" in result.columns
+    assert "ancestor_list" in result.columns
+    assert "origin_time" in result.columns
+
+
+def test_empty_data_no_ancestor_list():
+    spop = "#filetype genotype_data\n#format id src parents update_born\n"
+    result = alifestd_from_avida_spop(spop, create_ancestor_list=False)
+    assert len(result) == 0
+    assert "id" in result.columns
+    assert "ancestor_list" not in result.columns
+    assert "origin_time" in result.columns
+
+
+def test_missing_header():
+    spop = "#filetype genotype_data\n# no format line here\n"
+    with pytest.raises(ValueError, match="Failed to find #format header"):
+        alifestd_from_avida_spop(spop)
+
+
+def test_single_root_organism():
+    spop = (
+        "#filetype genotype_data\n"
+        "#format id src parents update_born\n"
+        "1 org:file (none) 0\n"
+    )
+    result = alifestd_from_avida_spop(spop)
+    assert len(result) == 1
+    assert result["id"].iloc[0] == 1
+    assert result["ancestor_list"].iloc[0] == "[none]"
+    assert result["origin_time"].iloc[0] == 0
+
+
+def test_asexual_parent_child():
+    spop = (
+        "#filetype genotype_data\n"
+        "#format id src parents update_born\n"
+        "1 org:file (none) 0\n"
+        "2 div:int 1 100\n"
+    )
+    result = alifestd_from_avida_spop(spop)
+    assert len(result) == 2
+    assert result["ancestor_list"].iloc[0] == "[none]"
+    assert result["ancestor_list"].iloc[1] == "[1]"
+
+
+def test_sexual_parents():
+    spop = (
+        "#filetype genotype_data\n"
+        "#format id src parents update_born\n"
+        "100 org:file (none) 0\n"
+        "200 org:file (none) 0\n"
+        "300 div:sex 100,200 100\n"
+    )
+    result = alifestd_from_avida_spop(spop)
+    assert len(result) == 3
+    assert result["ancestor_list"].iloc[0] == "[none]"
+    assert result["ancestor_list"].iloc[1] == "[none]"
+    assert result["ancestor_list"].iloc[2] == "[100,200]"
+
+
+def test_asexual_asset():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop(spop)
+
+    assert len(result) == 5
+    assert "id" in result.columns
+    assert "ancestor_list" in result.columns
+    assert "origin_time" in result.columns
+
+    # Root organism has (none) parent -> [none] ancestor_list
+    root = result[result["id"] == 1]
+    assert len(root) == 1
+    assert root["ancestor_list"].iloc[0] == "[none]"
+    assert root["origin_time"].iloc[0] == 0
+
+    # Organism 2 descends from 1
+    org2 = result[result["id"] == 2]
+    assert org2["ancestor_list"].iloc[0] == "[1]"
+    assert org2["origin_time"].iloc[0] == 100
+
+    # Organism 4 descends from 2
+    org4 = result[result["id"] == 4]
+    assert org4["ancestor_list"].iloc[0] == "[2]"
+    assert org4["origin_time"].iloc[0] == 300
+
+
+def test_sexual_asset():
+    spop = _read_asset("example-avida-sexual.spop")
+    result = alifestd_from_avida_spop(spop)
+
+    assert len(result) == 4
+
+    # Root organisms
+    org100 = result[result["id"] == 100]
+    assert org100["ancestor_list"].iloc[0] == "[none]"
+
+    org200 = result[result["id"] == 200]
+    assert org200["ancestor_list"].iloc[0] == "[none]"
+
+    # Sexual offspring with two parents
+    org300 = result[result["id"] == 300]
+    assert org300["ancestor_list"].iloc[0] == "[100,200]"
+    assert org300["origin_time"].iloc[0] == 100
+
+
+def test_extra_columns_preserved():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop(spop)
+
+    # Check that extra Avida fields are preserved
+    assert "src" in result.columns
+    assert "merit" in result.columns
+    assert "fitness" in result.columns
+    assert "depth" in result.columns
+    assert "sequence" in result.columns
+
+
+def test_no_ancestor_list():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop(spop, create_ancestor_list=False)
+    assert "ancestor_list" not in result.columns
+    assert "id" in result.columns
+    assert "origin_time" in result.columns
+
+
+def test_comment_and_blank_lines_skipped():
+    spop = (
+        "#filetype genotype_data\n"
+        "# This is a comment\n"
+        "\n"
+        "#format id src parents update_born\n"
+        "# Another comment\n"
+        "\n"
+        "1 org:file (none) 0\n"
+        "\n"
+        "# trailing comment\n"
+    )
+    result = alifestd_from_avida_spop(spop)
+    assert len(result) == 1
+
+
+def test_missing_trailing_fields():
+    spop = (
+        "#filetype genotype_data\n"
+        "#format id src parents update_born depth sequence\n"
+        "1 org:file (none) 0\n"
+    )
+    result = alifestd_from_avida_spop(spop)
+    assert len(result) == 1
+    assert result["id"].iloc[0] == 1
+    # Missing fields should be "NONE"
+    assert result["depth"].iloc[0] == "NONE"
+    assert result["sequence"].iloc[0] == "NONE"
+
+
+def test_column_order():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop(spop)
+
+    cols = list(result.columns)
+    # id, ancestor_list, and origin_time should be the first three
+    assert cols[0] == "id"
+    assert cols[1] == "ancestor_list"
+    assert cols[2] == "origin_time"
+
+
+def test_id_dtype():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop(spop)
+    assert result["id"].dtype == np.int64
+
+
+def test_origin_time_dtype():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop(spop)
+    assert result["origin_time"].dtype == np.int64
+
+
+def test_returns_dataframe():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop(spop)
+    assert isinstance(result, pd.DataFrame)

--- a/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop.py
@@ -22,6 +22,14 @@ def test_empty_data():
     assert "ancestor_list" in result.columns
 
 
+def test_empty_data_no_ancestor_list():
+    spop = "#filetype genotype_data\n#format id src parents update_born\n"
+    result = alifestd_from_avida_spop(spop, create_ancestor_list=False)
+    assert len(result) == 0
+    assert "id" in result.columns
+    assert "ancestor_list" not in result.columns
+
+
 def test_missing_header():
     spop = "#filetype genotype_data\n# no format line here\n"
     with pytest.raises(ValueError, match="Failed to find #format header"):

--- a/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop.py
@@ -36,6 +36,23 @@ def test_missing_header():
         alifestd_from_avida_spop(spop)
 
 
+def test_missing_required_column():
+    spop = "#filetype genotype_data\n" "#format id src\n" "1 org:file\n"
+    with pytest.raises(ValueError, match="Required column"):
+        alifestd_from_avida_spop(spop)
+
+
+def test_duplicate_ids():
+    spop = (
+        "#filetype genotype_data\n"
+        "#format id src parents update_born\n"
+        "1 org:file (none) 0\n"
+        "1 div:int (none) 100\n"
+    )
+    with pytest.raises(ValueError, match="IDs must be unique"):
+        alifestd_from_avida_spop(spop)
+
+
 def test_single_root_organism():
     spop = (
         "#filetype genotype_data\n"

--- a/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop_polars.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop_polars.py
@@ -38,6 +38,23 @@ def test_missing_header():
         alifestd_from_avida_spop_polars(spop)
 
 
+def test_missing_required_column():
+    spop = "#filetype genotype_data\n" "#format id src\n" "1 org:file\n"
+    with pytest.raises(ValueError, match="Required column"):
+        alifestd_from_avida_spop_polars(spop)
+
+
+def test_duplicate_ids():
+    spop = (
+        "#filetype genotype_data\n"
+        "#format id src parents update_born\n"
+        "1 org:file (none) 0\n"
+        "1 div:int (none) 100\n"
+    )
+    with pytest.raises(ValueError, match="IDs must be unique"):
+        alifestd_from_avida_spop_polars(spop)
+
+
 def test_single_root_organism():
     spop = (
         "#filetype genotype_data\n"

--- a/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop_polars.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop_polars.py
@@ -21,16 +21,16 @@ def test_empty_data():
     result = alifestd_from_avida_spop_polars(spop)
     assert len(result) == 0
     assert "id" in result.columns
-    assert "ancestor_list" in result.columns
+    assert "ancestor_list" not in result.columns
     assert "origin_time" in result.columns
 
 
-def test_empty_data_no_ancestor_list():
+def test_empty_data_with_ancestor_list():
     spop = "#filetype genotype_data\n#format id src parents update_born\n"
-    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=False)
+    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=True)
     assert len(result) == 0
     assert "id" in result.columns
-    assert "ancestor_list" not in result.columns
+    assert "ancestor_list" in result.columns
     assert "origin_time" in result.columns
 
 
@@ -46,7 +46,7 @@ def test_single_root_organism():
         "#format id src parents update_born\n"
         "1 org:file (none) 0\n"
     )
-    result = alifestd_from_avida_spop_polars(spop)
+    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=True)
     assert len(result) == 1
     assert result["id"][0] == 1
     assert result["ancestor_list"][0] == "[none]"
@@ -60,7 +60,7 @@ def test_asexual_parent_child():
         "1 org:file (none) 0\n"
         "2 div:int 1 100\n"
     )
-    result = alifestd_from_avida_spop_polars(spop)
+    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=True)
     assert len(result) == 2
     assert result["ancestor_list"][0] == "[none]"
     assert result["ancestor_list"][1] == "[1]"
@@ -74,7 +74,7 @@ def test_sexual_parents():
         "200 org:file (none) 0\n"
         "300 div:sex 100,200 100\n"
     )
-    result = alifestd_from_avida_spop_polars(spop)
+    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=True)
     assert len(result) == 3
     assert result["ancestor_list"][0] == "[none]"
     assert result["ancestor_list"][1] == "[none]"
@@ -83,7 +83,7 @@ def test_sexual_parents():
 
 def test_asexual_asset():
     spop = _read_asset("example-avida-asexual.spop")
-    result = alifestd_from_avida_spop_polars(spop)
+    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=True)
 
     assert len(result) == 5
     assert "id" in result.columns
@@ -109,7 +109,7 @@ def test_asexual_asset():
 
 def test_sexual_asset():
     spop = _read_asset("example-avida-sexual.spop")
-    result = alifestd_from_avida_spop_polars(spop)
+    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=True)
 
     assert len(result) == 4
 
@@ -139,7 +139,7 @@ def test_extra_columns_preserved():
 
 def test_no_ancestor_list():
     spop = _read_asset("example-avida-asexual.spop")
-    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=False)
+    result = alifestd_from_avida_spop_polars(spop)
     assert "ancestor_list" not in result.columns
     assert "id" in result.columns
     assert "origin_time" in result.columns
@@ -177,7 +177,7 @@ def test_missing_trailing_fields():
 
 def test_column_order():
     spop = _read_asset("example-avida-asexual.spop")
-    result = alifestd_from_avida_spop_polars(spop)
+    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=True)
 
     cols = list(result.columns)
     assert cols[0] == "id"
@@ -206,8 +206,10 @@ def test_returns_dataframe():
 def test_matches_pandas():
     """Verify polars output matches pandas output."""
     spop = _read_asset("example-avida-asexual.spop")
-    pd_result = alifestd_from_avida_spop(spop)
-    pl_result = alifestd_from_avida_spop_polars(spop)
+    pd_result = alifestd_from_avida_spop(spop, create_ancestor_list=True)
+    pl_result = alifestd_from_avida_spop_polars(
+        spop, create_ancestor_list=True
+    )
 
     assert len(pd_result) == len(pl_result)
 
@@ -218,10 +220,44 @@ def test_matches_pandas():
 def test_matches_pandas_sexual():
     """Verify polars output matches pandas output for sexual data."""
     spop = _read_asset("example-avida-sexual.spop")
-    pd_result = alifestd_from_avida_spop(spop)
-    pl_result = alifestd_from_avida_spop_polars(spop)
+    pd_result = alifestd_from_avida_spop(spop, create_ancestor_list=True)
+    pl_result = alifestd_from_avida_spop_polars(
+        spop, create_ancestor_list=True
+    )
 
     assert len(pd_result) == len(pl_result)
 
     for col in ["id", "ancestor_list", "origin_time"]:
         assert list(pd_result[col]) == pl_result[col].to_list()
+
+
+def test_dtype_id_default():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop_polars(spop)
+    assert result["id"].dtype == pl.Int64
+
+
+def test_dtype_id_int32():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop_polars(spop, dtype_id=pl.Int32)
+    assert result["id"].dtype == pl.Int32
+
+
+def test_dtype_id_none_small():
+    spop = (
+        "#filetype genotype_data\n"
+        "#format id src parents update_born\n"
+        "1 org:file (none) 0\n"
+        "2 div:int 1 100\n"
+    )
+    result = alifestd_from_avida_spop_polars(spop, dtype_id=None)
+    # max id 2 -> min_scalar_type(-2) -> Int8
+    assert result["id"].dtype == pl.Int8
+    assert len(result) == 2
+
+
+def test_dtype_id_none_empty():
+    spop = "#filetype genotype_data\n#format id src parents update_born\n"
+    result = alifestd_from_avida_spop_polars(spop, dtype_id=None)
+    assert result["id"].dtype == pl.Int8
+    assert len(result) == 0

--- a/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop_polars.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop_polars.py
@@ -21,16 +21,16 @@ def test_empty_data():
     result = alifestd_from_avida_spop_polars(spop)
     assert len(result) == 0
     assert "id" in result.columns
-    assert "ancestor_list" not in result.columns
+    assert "ancestor_list" in result.columns
     assert "origin_time" in result.columns
 
 
-def test_empty_data_with_ancestor_list():
+def test_empty_data_no_ancestor_list():
     spop = "#filetype genotype_data\n#format id src parents update_born\n"
-    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=True)
+    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=False)
     assert len(result) == 0
     assert "id" in result.columns
-    assert "ancestor_list" in result.columns
+    assert "ancestor_list" not in result.columns
     assert "origin_time" in result.columns
 
 
@@ -46,7 +46,7 @@ def test_single_root_organism():
         "#format id src parents update_born\n"
         "1 org:file (none) 0\n"
     )
-    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=True)
+    result = alifestd_from_avida_spop_polars(spop)
     assert len(result) == 1
     assert result["id"][0] == 1
     assert result["ancestor_list"][0] == "[none]"
@@ -60,7 +60,7 @@ def test_asexual_parent_child():
         "1 org:file (none) 0\n"
         "2 div:int 1 100\n"
     )
-    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=True)
+    result = alifestd_from_avida_spop_polars(spop)
     assert len(result) == 2
     assert result["ancestor_list"][0] == "[none]"
     assert result["ancestor_list"][1] == "[1]"
@@ -74,7 +74,7 @@ def test_sexual_parents():
         "200 org:file (none) 0\n"
         "300 div:sex 100,200 100\n"
     )
-    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=True)
+    result = alifestd_from_avida_spop_polars(spop)
     assert len(result) == 3
     assert result["ancestor_list"][0] == "[none]"
     assert result["ancestor_list"][1] == "[none]"
@@ -83,7 +83,7 @@ def test_sexual_parents():
 
 def test_asexual_asset():
     spop = _read_asset("example-avida-asexual.spop")
-    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=True)
+    result = alifestd_from_avida_spop_polars(spop)
 
     assert len(result) == 5
     assert "id" in result.columns
@@ -109,7 +109,7 @@ def test_asexual_asset():
 
 def test_sexual_asset():
     spop = _read_asset("example-avida-sexual.spop")
-    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=True)
+    result = alifestd_from_avida_spop_polars(spop)
 
     assert len(result) == 4
 
@@ -139,7 +139,7 @@ def test_extra_columns_preserved():
 
 def test_no_ancestor_list():
     spop = _read_asset("example-avida-asexual.spop")
-    result = alifestd_from_avida_spop_polars(spop)
+    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=False)
     assert "ancestor_list" not in result.columns
     assert "id" in result.columns
     assert "origin_time" in result.columns
@@ -177,7 +177,7 @@ def test_missing_trailing_fields():
 
 def test_column_order():
     spop = _read_asset("example-avida-asexual.spop")
-    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=True)
+    result = alifestd_from_avida_spop_polars(spop)
 
     cols = list(result.columns)
     assert cols[0] == "id"
@@ -206,10 +206,8 @@ def test_returns_dataframe():
 def test_matches_pandas():
     """Verify polars output matches pandas output."""
     spop = _read_asset("example-avida-asexual.spop")
-    pd_result = alifestd_from_avida_spop(spop, create_ancestor_list=True)
-    pl_result = alifestd_from_avida_spop_polars(
-        spop, create_ancestor_list=True
-    )
+    pd_result = alifestd_from_avida_spop(spop)
+    pl_result = alifestd_from_avida_spop_polars(spop)
 
     assert len(pd_result) == len(pl_result)
 
@@ -220,10 +218,8 @@ def test_matches_pandas():
 def test_matches_pandas_sexual():
     """Verify polars output matches pandas output for sexual data."""
     spop = _read_asset("example-avida-sexual.spop")
-    pd_result = alifestd_from_avida_spop(spop, create_ancestor_list=True)
-    pl_result = alifestd_from_avida_spop_polars(
-        spop, create_ancestor_list=True
-    )
+    pd_result = alifestd_from_avida_spop(spop)
+    pl_result = alifestd_from_avida_spop_polars(spop)
 
     assert len(pd_result) == len(pl_result)
 

--- a/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop_polars.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop_polars.py
@@ -21,17 +21,6 @@ def test_empty_data():
     result = alifestd_from_avida_spop_polars(spop)
     assert len(result) == 0
     assert "id" in result.columns
-    assert "ancestor_list" in result.columns
-    assert "origin_time" in result.columns
-
-
-def test_empty_data_no_ancestor_list():
-    spop = "#filetype genotype_data\n#format id src parents update_born\n"
-    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=False)
-    assert len(result) == 0
-    assert "id" in result.columns
-    assert "ancestor_list" not in result.columns
-    assert "origin_time" in result.columns
 
 
 def test_missing_header():
@@ -225,35 +214,3 @@ def test_matches_pandas_sexual():
 
     for col in ["id", "ancestor_list", "origin_time"]:
         assert list(pd_result[col]) == pl_result[col].to_list()
-
-
-def test_dtype_id_default():
-    spop = _read_asset("example-avida-asexual.spop")
-    result = alifestd_from_avida_spop_polars(spop)
-    assert result["id"].dtype == pl.Int64
-
-
-def test_dtype_id_int32():
-    spop = _read_asset("example-avida-asexual.spop")
-    result = alifestd_from_avida_spop_polars(spop, dtype_id=pl.Int32)
-    assert result["id"].dtype == pl.Int32
-
-
-def test_dtype_id_none_small():
-    spop = (
-        "#filetype genotype_data\n"
-        "#format id src parents update_born\n"
-        "1 org:file (none) 0\n"
-        "2 div:int 1 100\n"
-    )
-    result = alifestd_from_avida_spop_polars(spop, dtype_id=None)
-    # max id 2 -> min_scalar_type(-2) -> Int8
-    assert result["id"].dtype == pl.Int8
-    assert len(result) == 2
-
-
-def test_dtype_id_none_empty():
-    spop = "#filetype genotype_data\n#format id src parents update_born\n"
-    result = alifestd_from_avida_spop_polars(spop, dtype_id=None)
-    assert result["id"].dtype == pl.Int8
-    assert len(result) == 0

--- a/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop_polars.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop_polars.py
@@ -214,3 +214,28 @@ def test_matches_pandas_sexual():
 
     for col in ["id", "ancestor_list", "origin_time"]:
         assert list(pd_result[col]) == pl_result[col].to_list()
+
+
+def test_dtype_id_default():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop_polars(spop)
+    assert result["id"].dtype == pl.Int64
+
+
+def test_dtype_id_int32():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop_polars(spop, dtype_id=pl.Int32)
+    assert result["id"].dtype == pl.Int32
+
+
+def test_dtype_id_none_small():
+    spop = (
+        "#filetype genotype_data\n"
+        "#format id src parents update_born\n"
+        "1 org:file (none) 0\n"
+        "2 div:int 1 100\n"
+    )
+    result = alifestd_from_avida_spop_polars(spop, dtype_id=None)
+    # 2 rows -> min_scalar_type(-2) -> Int8
+    assert result["id"].dtype == pl.Int8
+    assert len(result) == 2

--- a/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop_polars.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop_polars.py
@@ -1,0 +1,227 @@
+import os
+
+import polars as pl
+import pytest
+
+from phyloframe.legacy import (
+    alifestd_from_avida_spop,
+    alifestd_from_avida_spop_polars,
+)
+
+assets_path = os.path.join(os.path.dirname(__file__), "assets")
+
+
+def _read_asset(name: str) -> str:
+    with open(os.path.join(assets_path, name)) as f:
+        return f.read()
+
+
+def test_empty_data():
+    spop = "#filetype genotype_data\n#format id src parents update_born\n"
+    result = alifestd_from_avida_spop_polars(spop)
+    assert len(result) == 0
+    assert "id" in result.columns
+    assert "ancestor_list" in result.columns
+    assert "origin_time" in result.columns
+
+
+def test_empty_data_no_ancestor_list():
+    spop = "#filetype genotype_data\n#format id src parents update_born\n"
+    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=False)
+    assert len(result) == 0
+    assert "id" in result.columns
+    assert "ancestor_list" not in result.columns
+    assert "origin_time" in result.columns
+
+
+def test_missing_header():
+    spop = "#filetype genotype_data\n# no format line here\n"
+    with pytest.raises(ValueError, match="Failed to find #format header"):
+        alifestd_from_avida_spop_polars(spop)
+
+
+def test_single_root_organism():
+    spop = (
+        "#filetype genotype_data\n"
+        "#format id src parents update_born\n"
+        "1 org:file (none) 0\n"
+    )
+    result = alifestd_from_avida_spop_polars(spop)
+    assert len(result) == 1
+    assert result["id"][0] == 1
+    assert result["ancestor_list"][0] == "[none]"
+    assert result["origin_time"][0] == 0
+
+
+def test_asexual_parent_child():
+    spop = (
+        "#filetype genotype_data\n"
+        "#format id src parents update_born\n"
+        "1 org:file (none) 0\n"
+        "2 div:int 1 100\n"
+    )
+    result = alifestd_from_avida_spop_polars(spop)
+    assert len(result) == 2
+    assert result["ancestor_list"][0] == "[none]"
+    assert result["ancestor_list"][1] == "[1]"
+
+
+def test_sexual_parents():
+    spop = (
+        "#filetype genotype_data\n"
+        "#format id src parents update_born\n"
+        "100 org:file (none) 0\n"
+        "200 org:file (none) 0\n"
+        "300 div:sex 100,200 100\n"
+    )
+    result = alifestd_from_avida_spop_polars(spop)
+    assert len(result) == 3
+    assert result["ancestor_list"][0] == "[none]"
+    assert result["ancestor_list"][1] == "[none]"
+    assert result["ancestor_list"][2] == "[100,200]"
+
+
+def test_asexual_asset():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop_polars(spop)
+
+    assert len(result) == 5
+    assert "id" in result.columns
+    assert "ancestor_list" in result.columns
+    assert "origin_time" in result.columns
+
+    # Root organism
+    root = result.filter(pl.col("id") == 1)
+    assert len(root) == 1
+    assert root["ancestor_list"][0] == "[none]"
+    assert root["origin_time"][0] == 0
+
+    # Organism 2 descends from 1
+    org2 = result.filter(pl.col("id") == 2)
+    assert org2["ancestor_list"][0] == "[1]"
+    assert org2["origin_time"][0] == 100
+
+    # Organism 4 descends from 2
+    org4 = result.filter(pl.col("id") == 4)
+    assert org4["ancestor_list"][0] == "[2]"
+    assert org4["origin_time"][0] == 300
+
+
+def test_sexual_asset():
+    spop = _read_asset("example-avida-sexual.spop")
+    result = alifestd_from_avida_spop_polars(spop)
+
+    assert len(result) == 4
+
+    # Root organisms
+    org100 = result.filter(pl.col("id") == 100)
+    assert org100["ancestor_list"][0] == "[none]"
+
+    org200 = result.filter(pl.col("id") == 200)
+    assert org200["ancestor_list"][0] == "[none]"
+
+    # Sexual offspring with two parents
+    org300 = result.filter(pl.col("id") == 300)
+    assert org300["ancestor_list"][0] == "[100,200]"
+    assert org300["origin_time"][0] == 100
+
+
+def test_extra_columns_preserved():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop_polars(spop)
+
+    assert "src" in result.columns
+    assert "merit" in result.columns
+    assert "fitness" in result.columns
+    assert "depth" in result.columns
+    assert "sequence" in result.columns
+
+
+def test_no_ancestor_list():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=False)
+    assert "ancestor_list" not in result.columns
+    assert "id" in result.columns
+    assert "origin_time" in result.columns
+
+
+def test_comment_and_blank_lines_skipped():
+    spop = (
+        "#filetype genotype_data\n"
+        "# This is a comment\n"
+        "\n"
+        "#format id src parents update_born\n"
+        "# Another comment\n"
+        "\n"
+        "1 org:file (none) 0\n"
+        "\n"
+        "# trailing comment\n"
+    )
+    result = alifestd_from_avida_spop_polars(spop)
+    assert len(result) == 1
+
+
+def test_missing_trailing_fields():
+    spop = (
+        "#filetype genotype_data\n"
+        "#format id src parents update_born depth sequence\n"
+        "1 org:file (none) 0\n"
+    )
+    result = alifestd_from_avida_spop_polars(spop)
+    assert len(result) == 1
+    assert result["id"][0] == 1
+    # Missing fields should be "NONE"
+    assert result["depth"][0] == "NONE"
+    assert result["sequence"][0] == "NONE"
+
+
+def test_column_order():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop_polars(spop)
+
+    cols = list(result.columns)
+    assert cols[0] == "id"
+    assert cols[1] == "ancestor_list"
+    assert cols[2] == "origin_time"
+
+
+def test_id_dtype():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop_polars(spop)
+    assert result["id"].dtype == pl.Int64
+
+
+def test_origin_time_dtype():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop_polars(spop)
+    assert result["origin_time"].dtype == pl.Int64
+
+
+def test_returns_dataframe():
+    spop = _read_asset("example-avida-asexual.spop")
+    result = alifestd_from_avida_spop_polars(spop)
+    assert isinstance(result, pl.DataFrame)
+
+
+def test_matches_pandas():
+    """Verify polars output matches pandas output."""
+    spop = _read_asset("example-avida-asexual.spop")
+    pd_result = alifestd_from_avida_spop(spop)
+    pl_result = alifestd_from_avida_spop_polars(spop)
+
+    assert len(pd_result) == len(pl_result)
+
+    for col in ["id", "ancestor_list", "origin_time"]:
+        assert list(pd_result[col]) == pl_result[col].to_list()
+
+
+def test_matches_pandas_sexual():
+    """Verify polars output matches pandas output for sexual data."""
+    spop = _read_asset("example-avida-sexual.spop")
+    pd_result = alifestd_from_avida_spop(spop)
+    pl_result = alifestd_from_avida_spop_polars(spop)
+
+    assert len(pd_result) == len(pl_result)
+
+    for col in ["id", "ancestor_list", "origin_time"]:
+        assert list(pd_result[col]) == pl_result[col].to_list()

--- a/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop_polars.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop_polars.py
@@ -21,6 +21,15 @@ def test_empty_data():
     result = alifestd_from_avida_spop_polars(spop)
     assert len(result) == 0
     assert "id" in result.columns
+    assert "ancestor_list" in result.columns
+
+
+def test_empty_data_no_ancestor_list():
+    spop = "#filetype genotype_data\n#format id src parents update_born\n"
+    result = alifestd_from_avida_spop_polars(spop, create_ancestor_list=False)
+    assert len(result) == 0
+    assert "id" in result.columns
+    assert "ancestor_list" not in result.columns
 
 
 def test_missing_header():


### PR DESCRIPTION
## Summary
This PR adds support for parsing Avida `.spop` (structured population) files into alife-standard phylogeny dataframes. Both pandas and polars implementations are provided, allowing users to choose their preferred dataframe library.

## Key Changes
- **New module**: `phyloframe/legacy/_alifestd_from_avida_spop.py`
  - Implements `alifestd_from_avida_spop()` for pandas-based parsing
  - Shared parsing utilities: `_parse_spop_header()` and `_parse_spop_ancestor_list()`
  - Handles Avida field mapping to alife standard column names
  - Supports both asexual (single parent) and sexual (multiple parents) reproduction

- **New module**: `phyloframe/legacy/_alifestd_from_avida_spop_polars.py`
  - Implements `alifestd_from_avida_spop_polars()` for polars-based parsing
  - Reuses shared parsing utilities from the pandas implementation
  - Returns polars DataFrames with proper type casting

- **Comprehensive test suites**:
  - `tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop.py` (203 lines)
  - `tests/test_phyloframe/test_legacy/test_alifestd_from_avida_spop_polars.py` (227 lines)
  - Tests cover: empty data, missing headers, single/multiple parents, asset files, column ordering, data types, and pandas/polars equivalence

- **Test fixtures**:
  - `example-avida-asexual.spop`: 5-organism asexual lineage
  - `example-avida-sexual.spop`: 4-organism population with sexual reproduction

- **Updated exports**: Added new functions to `phyloframe/legacy/__init__.pyi`

## Implementation Details
- Parses Avida SPOP format by extracting field names from `#format` header and processing data rows
- Converts Avida `parents` field (comma-delimited IDs or "(none)") to alife-standard `ancestor_list` format ("[id1,id2]" or "[none]")
- Maps `update_born` to `origin_time` and preserves additional Avida-specific fields
- Handles missing trailing fields by filling with "NONE"
- Both implementations maintain consistent column ordering: id, ancestor_list, origin_time, then other fields
- Optional `create_ancestor_list` parameter allows skipping ancestor_list column creation

https://claude.ai/code/session_018zVisPqKHHzoZmhxDACQYD