### PR TITLE
Add compression support for output files

### DIFF
--- a/phyloframe/_auxlib/__init__.pyi
+++ b/phyloframe/_auxlib/__init__.pyi
@@ -1,6 +1,7 @@
 from ._GetAttrLaunderShim import GetAttrLaunderShim
 from ._RngStateContext import RngStateContext
 from ._add_bool_arg import add_bool_arg
+from ._add_compression_cli_arg import add_compression_cli_arg
 from ._all_unique import all_unique
 from ._begin_prod_logging import begin_prod_logging
 from ._coerce_to_pandas import coerce_to_pandas
@@ -41,11 +42,13 @@ from ._unfurl_lineage_with_contiguous_ids import (
 )
 from ._warn_once import warn_once
 from ._with_rng_state_context import with_rng_state_context
+from ._write_text_with_compression import write_text_with_compression
 
 __all__ = [
     "GetAttrLaunderShim",
     "RngStateContext",
     "add_bool_arg",
+    "add_compression_cli_arg",
     "all_unique",
     "begin_prod_logging",
     "coerce_to_pandas",
@@ -82,4 +85,5 @@ __all__ = [
     "unfurl_lineage_with_contiguous_ids",
     "warn_once",
     "with_rng_state_context",
+    "write_text_with_compression",
 ]

--- a/phyloframe/_auxlib/_add_compression_cli_arg.py
+++ b/phyloframe/_auxlib/_add_compression_cli_arg.py
@@ -1,0 +1,27 @@
+import argparse
+
+_SUPPORTED_COMPRESSIONS = ("gzip", "bz2", "xz", "zip")
+
+
+def add_compression_cli_arg(parser: argparse.ArgumentParser) -> None:
+    """Add a ``--compression`` argument to *parser*.
+
+    Supported compression formats are gzip, bz2, xz, and zip — all
+    provided by the Python standard library.
+
+    Parameters
+    ----------
+    parser : argparse.ArgumentParser
+        The argument parser to add the flag to.
+    """
+    parser.add_argument(
+        "--compression",
+        type=str,
+        choices=_SUPPORTED_COMPRESSIONS,
+        default=None,
+        help=(
+            "Compression format for the output file. "
+            "Supported: gzip, bz2, xz, zip. "
+            "If not set, output is written uncompressed."
+        ),
+    )

--- a/phyloframe/_auxlib/_write_text_with_compression.py
+++ b/phyloframe/_auxlib/_write_text_with_compression.py
@@ -1,0 +1,82 @@
+import bz2
+import gzip
+import logging
+import lzma
+import pathlib
+import typing
+import zipfile
+
+_COMPRESSED_EXTENSIONS = {
+    ".gz": "gzip",
+    ".bz2": "bz2",
+    ".xz": "xz",
+    ".zip": "zip",
+    ".zst": "zstd",
+}
+
+
+def write_text_with_compression(
+    path: str,
+    text: str,
+    compression: typing.Optional[str] = None,
+) -> None:
+    """Write text to a file, optionally with compression.
+
+    Parameters
+    ----------
+    path : str
+        Output file path.
+    text : str
+        Text content to write.
+    compression : str or None, optional
+        Compression format: 'gzip', 'bz2', 'xz', 'zip', or None.
+
+    Raises
+    ------
+    ValueError
+        If the file extension implies compression but doesn't match the
+        ``--compression`` flag, or if an unsupported compression format
+        is requested.
+    """
+    path = pathlib.Path(path)
+    ext = path.suffix.lower()
+
+    if ext in _COMPRESSED_EXTENSIONS:
+        expected = _COMPRESSED_EXTENSIONS[ext]
+        if compression is None:
+            raise ValueError(
+                f"Output filename ends in '{ext}', which implies "
+                f"'{expected}' compression, but --compression was not "
+                f"set. Pass --compression {expected} to confirm, or use "
+                f"a different filename.",
+            )
+        if compression != expected:
+            raise ValueError(
+                f"Output filename ends in '{ext}', which implies "
+                f"'{expected}' compression, but --compression was set to "
+                f"'{compression}'. Use a matching extension or change "
+                f"--compression.",
+            )
+
+    if compression is None:
+        logging.info(f"writing uncompressed output to {path}...")
+        path.write_text(text)
+    elif compression == "gzip":
+        logging.info(f"writing gzip-compressed output to {path}...")
+        with gzip.open(path, "wt") as f:
+            f.write(text)
+    elif compression == "bz2":
+        logging.info(f"writing bz2-compressed output to {path}...")
+        with bz2.open(path, "wt") as f:
+            f.write(text)
+    elif compression == "xz":
+        logging.info(f"writing xz-compressed output to {path}...")
+        with lzma.open(path, "wt") as f:
+            f.write(text)
+    elif compression == "zip":
+        logging.info(f"writing zip-compressed output to {path}...")
+        member_name = path.stem
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr(member_name, text)
+    else:
+        raise ValueError(f"Unsupported compression format: {compression!r}")

--- a/phyloframe/legacy/_alifestd_as_newick_asexual.py
+++ b/phyloframe/legacy/_alifestd_as_newick_asexual.py
@@ -1,7 +1,6 @@
 import argparse
 import logging
 import os
-import pathlib
 import typing
 
 import more_itertools as mit
@@ -11,11 +10,15 @@ import pandas as pd
 import polars as pl
 from tqdm import tqdm
 
+from .._auxlib._add_compression_cli_arg import add_compression_cli_arg
 from .._auxlib._begin_prod_logging import begin_prod_logging
 from .._auxlib._eval_kwargs import eval_kwargs
 from .._auxlib._format_cli_description import format_cli_description
 from .._auxlib._get_phyloframe_version import get_phyloframe_version
 from .._auxlib._log_context_duration import log_context_duration
+from .._auxlib._write_text_with_compression import (
+    write_text_with_compression,
+)
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_mark_origin_time_delta_asexual import (
     alifestd_mark_origin_time_delta_asexual,
@@ -201,6 +204,7 @@ def _create_parser() -> argparse.ArgumentParser:
         help="Name of column to use as taxon label.",
         required=False,
     )
+    add_compression_cli_arg(parser)
     parser.add_argument(
         "-v",
         "--version",
@@ -251,6 +255,6 @@ if __name__ == "__main__":
         )
 
     logging.info(f"writing Newick-formatted data to {args.output_file}...")
-    pathlib.Path(args.output_file).write_text(newick_str)
+    write_text_with_compression(args.output_file, newick_str, args.compression)
 
     logging.info("done!")

--- a/phyloframe/legacy/_alifestd_as_newick_polars.py
+++ b/phyloframe/legacy/_alifestd_as_newick_polars.py
@@ -1,18 +1,21 @@
 import argparse
 import logging
 import os
-import pathlib
 import typing
 
 import opytional as opyt
 import polars as pl
 from tqdm import tqdm
 
+from .._auxlib._add_compression_cli_arg import add_compression_cli_arg
 from .._auxlib._begin_prod_logging import begin_prod_logging
 from .._auxlib._eval_kwargs import eval_kwargs
 from .._auxlib._format_cli_description import format_cli_description
 from .._auxlib._get_phyloframe_version import get_phyloframe_version
 from .._auxlib._log_context_duration import log_context_duration
+from .._auxlib._write_text_with_compression import (
+    write_text_with_compression,
+)
 from ._alifestd_has_contiguous_ids_polars import (
     alifestd_has_contiguous_ids_polars,
 )
@@ -323,6 +326,7 @@ def _create_parser() -> argparse.ArgumentParser:
         help="Name of column to use as taxon label.",
         required=False,
     )
+    add_compression_cli_arg(parser)
     parser.add_argument(
         "-v",
         "--version",
@@ -364,6 +368,6 @@ if __name__ == "__main__":
         )
 
     logging.info(f"writing Newick-formatted data to {args.output_file}...")
-    pathlib.Path(args.output_file).write_text(newick_str)
+    write_text_with_compression(args.output_file, newick_str, args.compression)
 
     logging.info("done!")

--- a/tests/test_phyloframe/test_auxlib/test_add_compression_cli_arg.py
+++ b/tests/test_phyloframe/test_auxlib/test_add_compression_cli_arg.py
@@ -1,0 +1,48 @@
+import argparse
+
+import pytest
+
+from phyloframe._auxlib import add_compression_cli_arg
+
+
+def test_default_none():
+    parser = argparse.ArgumentParser()
+    add_compression_cli_arg(parser)
+    args = parser.parse_args([])
+    assert args.compression is None
+
+
+@pytest.mark.parametrize(
+    "compression",
+    ["gzip", "bz2", "xz", "zip"],
+)
+def test_supported_compression(compression: str):
+    parser = argparse.ArgumentParser()
+    add_compression_cli_arg(parser)
+    args = parser.parse_args(["--compression", compression])
+    assert args.compression == compression
+
+
+def test_unsupported_compression():
+    parser = argparse.ArgumentParser()
+    add_compression_cli_arg(parser)
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--compression", "zstd"])
+
+
+def test_unsupported_compression_lz4():
+    parser = argparse.ArgumentParser()
+    add_compression_cli_arg(parser)
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--compression", "lz4"])
+
+
+def test_with_other_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-o", "--output-file", type=str)
+    add_compression_cli_arg(parser)
+    args = parser.parse_args(
+        ["--output-file", "out.newick.gz", "--compression", "gzip"],
+    )
+    assert args.output_file == "out.newick.gz"
+    assert args.compression == "gzip"

--- a/tests/test_phyloframe/test_auxlib/test_write_text_with_compression.py
+++ b/tests/test_phyloframe/test_auxlib/test_write_text_with_compression.py
@@ -1,0 +1,192 @@
+import bz2
+import gzip
+import lzma
+import zipfile
+
+import pytest
+
+from phyloframe._auxlib import write_text_with_compression
+
+_SAMPLE_TEXT = "((A:1,B:2)C:3);\n"
+
+
+# --- uncompressed writing ---
+
+
+def test_write_uncompressed(tmp_path):
+    out = tmp_path / "out.newick"
+    write_text_with_compression(str(out), _SAMPLE_TEXT)
+    assert out.read_text() == _SAMPLE_TEXT
+
+
+def test_write_uncompressed_none_explicit(tmp_path):
+    out = tmp_path / "out.newick"
+    write_text_with_compression(str(out), _SAMPLE_TEXT, compression=None)
+    assert out.read_text() == _SAMPLE_TEXT
+
+
+# --- gzip ---
+
+
+def test_write_gzip(tmp_path):
+    out = tmp_path / "out.newick.gz"
+    write_text_with_compression(str(out), _SAMPLE_TEXT, compression="gzip")
+    assert out.exists()
+    assert out.stat().st_size > 0
+    with gzip.open(out, "rt") as f:
+        assert f.read() == _SAMPLE_TEXT
+
+
+def test_write_gzip_no_extension(tmp_path):
+    out = tmp_path / "out.newick"
+    write_text_with_compression(str(out), _SAMPLE_TEXT, compression="gzip")
+    with gzip.open(out, "rt") as f:
+        assert f.read() == _SAMPLE_TEXT
+
+
+# --- bz2 ---
+
+
+def test_write_bz2(tmp_path):
+    out = tmp_path / "out.newick.bz2"
+    write_text_with_compression(str(out), _SAMPLE_TEXT, compression="bz2")
+    assert out.exists()
+    assert out.stat().st_size > 0
+    with bz2.open(out, "rt") as f:
+        assert f.read() == _SAMPLE_TEXT
+
+
+def test_write_bz2_no_extension(tmp_path):
+    out = tmp_path / "out.newick"
+    write_text_with_compression(str(out), _SAMPLE_TEXT, compression="bz2")
+    with bz2.open(out, "rt") as f:
+        assert f.read() == _SAMPLE_TEXT
+
+
+# --- xz ---
+
+
+def test_write_xz(tmp_path):
+    out = tmp_path / "out.newick.xz"
+    write_text_with_compression(str(out), _SAMPLE_TEXT, compression="xz")
+    assert out.exists()
+    assert out.stat().st_size > 0
+    with lzma.open(out, "rt") as f:
+        assert f.read() == _SAMPLE_TEXT
+
+
+def test_write_xz_no_extension(tmp_path):
+    out = tmp_path / "out.newick"
+    write_text_with_compression(str(out), _SAMPLE_TEXT, compression="xz")
+    with lzma.open(out, "rt") as f:
+        assert f.read() == _SAMPLE_TEXT
+
+
+# --- zip ---
+
+
+def test_write_zip(tmp_path):
+    out = tmp_path / "out.newick.zip"
+    write_text_with_compression(str(out), _SAMPLE_TEXT, compression="zip")
+    assert out.exists()
+    assert out.stat().st_size > 0
+    with zipfile.ZipFile(out, "r") as zf:
+        names = zf.namelist()
+        assert len(names) == 1
+        assert names[0] == "out.newick"
+        assert zf.read(names[0]).decode() == _SAMPLE_TEXT
+
+
+def test_write_zip_no_extension(tmp_path):
+    out = tmp_path / "out.newick"
+    write_text_with_compression(str(out), _SAMPLE_TEXT, compression="zip")
+    with zipfile.ZipFile(out, "r") as zf:
+        assert zf.read(zf.namelist()[0]).decode() == _SAMPLE_TEXT
+
+
+# --- extension mismatch errors ---
+
+
+def test_gz_extension_no_compression(tmp_path):
+    out = tmp_path / "out.newick.gz"
+    with pytest.raises(ValueError, match="implies 'gzip' compression"):
+        write_text_with_compression(str(out), _SAMPLE_TEXT)
+
+
+def test_bz2_extension_no_compression(tmp_path):
+    out = tmp_path / "out.newick.bz2"
+    with pytest.raises(ValueError, match="implies 'bz2' compression"):
+        write_text_with_compression(str(out), _SAMPLE_TEXT)
+
+
+def test_xz_extension_no_compression(tmp_path):
+    out = tmp_path / "out.newick.xz"
+    with pytest.raises(ValueError, match="implies 'xz' compression"):
+        write_text_with_compression(str(out), _SAMPLE_TEXT)
+
+
+def test_zip_extension_no_compression(tmp_path):
+    out = tmp_path / "out.newick.zip"
+    with pytest.raises(ValueError, match="implies 'zip' compression"):
+        write_text_with_compression(str(out), _SAMPLE_TEXT)
+
+
+def test_zst_extension_no_compression(tmp_path):
+    out = tmp_path / "out.newick.zst"
+    with pytest.raises(ValueError, match="implies 'zstd' compression"):
+        write_text_with_compression(str(out), _SAMPLE_TEXT)
+
+
+def test_gz_extension_wrong_compression(tmp_path):
+    out = tmp_path / "out.newick.gz"
+    with pytest.raises(ValueError, match="implies 'gzip' compression"):
+        write_text_with_compression(str(out), _SAMPLE_TEXT, compression="bz2")
+
+
+def test_bz2_extension_wrong_compression(tmp_path):
+    out = tmp_path / "out.newick.bz2"
+    with pytest.raises(ValueError, match="implies 'bz2' compression"):
+        write_text_with_compression(str(out), _SAMPLE_TEXT, compression="gzip")
+
+
+def test_xz_extension_wrong_compression(tmp_path):
+    out = tmp_path / "out.newick.xz"
+    with pytest.raises(ValueError, match="implies 'xz' compression"):
+        write_text_with_compression(str(out), _SAMPLE_TEXT, compression="gzip")
+
+
+def test_zip_extension_wrong_compression(tmp_path):
+    out = tmp_path / "out.newick.zip"
+    with pytest.raises(ValueError, match="implies 'zip' compression"):
+        write_text_with_compression(str(out), _SAMPLE_TEXT, compression="gzip")
+
+
+def test_zst_extension_wrong_compression(tmp_path):
+    out = tmp_path / "out.newick.zst"
+    with pytest.raises(ValueError, match="implies 'zstd' compression"):
+        write_text_with_compression(str(out), _SAMPLE_TEXT, compression="gzip")
+
+
+# --- unsupported compression format ---
+
+
+def test_unsupported_compression(tmp_path):
+    out = tmp_path / "out.newick"
+    with pytest.raises(ValueError, match="Unsupported compression"):
+        write_text_with_compression(str(out), _SAMPLE_TEXT, compression="lz4")
+
+
+# --- empty text ---
+
+
+def test_write_gzip_empty(tmp_path):
+    out = tmp_path / "out.newick.gz"
+    write_text_with_compression(str(out), "", compression="gzip")
+    with gzip.open(out, "rt") as f:
+        assert f.read() == ""
+
+
+def test_write_uncompressed_empty(tmp_path):
+    out = tmp_path / "out.newick"
+    write_text_with_compression(str(out), "")
+    assert out.read_text() == ""

--- a/tests/test_phyloframe/test_legacy/test_alifestd_as_newick_asexual_cli.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_as_newick_asexual_cli.py
@@ -1,9 +1,26 @@
+import bz2
+import gzip
+import lzma
 import os
 import pathlib
 import subprocess
 import typing
+import zipfile
 
 import pytest
+
+_compression_ext_map = {
+    "gzip": ".gz",
+    "bz2": ".bz2",
+    "xz": ".xz",
+    "zip": ".zip",
+}
+
+_compression_opener = {
+    "gzip": lambda p: gzip.open(p, "rt"),
+    "bz2": lambda p: bz2.open(p, "rt"),
+    "xz": lambda p: lzma.open(p, "rt"),
+}
 
 assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
 
@@ -152,3 +169,57 @@ def test_alifestd_as_newick_asexual_cli_csv_input_kwarg(
     subprocess.run(cmd, check=True)  # nosec B603
     assert os.path.exists(output_file)
     assert os.path.getsize(output_file) > 0
+
+
+@pytest.mark.parametrize("compression", ["gzip", "bz2", "xz", "zip"])
+def test_alifestd_as_newick_asexual_cli_compression(compression: str):
+    ext = _compression_ext_map[compression]
+    output_file = (
+        "/tmp/phyloframe-as_newick_asexual_cli-"  # nosec B108
+        f"compression-{compression}.newick{ext}"
+    )
+    pathlib.Path(output_file).unlink(missing_ok=True)
+    cmd = [
+        "python3",
+        "-m",
+        "phyloframe.legacy._alifestd_as_newick_asexual",
+        "--input-file",
+        f"{assets}/nk_ecoeaselection.csv",
+        "--compression",
+        compression,
+        "-o",
+        output_file,
+    ]
+    subprocess.run(cmd, check=True)  # nosec B603
+    assert os.path.exists(output_file)
+    assert os.path.getsize(output_file) > 0
+
+    if compression == "zip":
+        with zipfile.ZipFile(output_file, "r") as zf:
+            content = zf.read(zf.namelist()[0]).decode()
+    else:
+        with _compression_opener[compression](output_file) as f:
+            content = f.read()
+    assert ";" in content
+
+
+@pytest.mark.parametrize(
+    "ext",
+    [".gz", ".bz2", ".xz", ".zip", ".zst"],
+)
+def test_alifestd_as_newick_asexual_cli_extension_without_flag(ext: str):
+    output_file = (
+        "/tmp/phyloframe-as_newick_asexual_cli-"  # nosec B108
+        f"ext-mismatch{ext}"
+    )
+    cmd = [
+        "python3",
+        "-m",
+        "phyloframe.legacy._alifestd_as_newick_asexual",
+        "--input-file",
+        f"{assets}/nk_ecoeaselection.csv",
+        "-o",
+        output_file,
+    ]
+    result = subprocess.run(cmd, capture_output=True)  # nosec B603
+    assert result.returncode != 0

--- a/tests/test_phyloframe/test_legacy/test_alifestd_as_newick_polars_cli.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_as_newick_polars_cli.py
@@ -1,0 +1,140 @@
+import bz2
+import gzip
+import lzma
+import os
+import pathlib
+import subprocess
+import typing
+import zipfile
+
+import pytest
+
+assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
+
+_compression_ext_map = {
+    "gzip": ".gz",
+    "bz2": ".bz2",
+    "xz": ".xz",
+    "zip": ".zip",
+}
+
+_compression_opener = {
+    "gzip": lambda p: gzip.open(p, "rt"),
+    "bz2": lambda p: bz2.open(p, "rt"),
+    "xz": lambda p: lzma.open(p, "rt"),
+}
+
+
+def test_alifestd_as_newick_polars_cli_help():
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "phyloframe.legacy._alifestd_as_newick_polars",
+            "--help",
+        ],
+        check=True,
+    )
+
+
+def test_alifestd_as_newick_polars_cli_version():
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "phyloframe.legacy._alifestd_as_newick_polars",
+            "--version",
+        ],
+        check=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "input_file",
+    [
+        "example-standard-toy-asexual-phylogeny.csv",
+    ],
+)
+@pytest.mark.parametrize(
+    "taxon_label",
+    [
+        None,
+        "id",
+    ],
+)
+def test_alifestd_as_newick_polars_cli_csv(
+    input_file: str, taxon_label: typing.Optional[str]
+):
+    output_file = (
+        "/tmp/phyloframe-as_newick_polars_cli-"  # nosec B108
+        f"{taxon_label}-{input_file}.newick"
+    )
+    pathlib.Path(output_file).unlink(missing_ok=True)
+    cmd = [
+        "python3",
+        "-m",
+        "phyloframe.legacy._alifestd_as_newick_polars",
+        "--input-file",
+        f"{assets}/{input_file}",
+        "-o",
+        output_file,
+    ]
+    if taxon_label is not None:
+        cmd.extend(["--taxon-label", taxon_label])
+    subprocess.run(cmd, check=True)  # nosec B603
+    assert os.path.exists(output_file)
+    assert os.path.getsize(output_file) > 0
+
+
+@pytest.mark.parametrize("compression", ["gzip", "bz2", "xz", "zip"])
+def test_alifestd_as_newick_polars_cli_compression(compression: str):
+    ext = _compression_ext_map[compression]
+    output_file = (
+        "/tmp/phyloframe-as_newick_polars_cli-"  # nosec B108
+        f"compression-{compression}.newick{ext}"
+    )
+    pathlib.Path(output_file).unlink(missing_ok=True)
+    cmd = [
+        "python3",
+        "-m",
+        "phyloframe.legacy._alifestd_as_newick_polars",
+        "--input-file",
+        f"{assets}/example-standard-toy-asexual-phylogeny.csv",
+        "--compression",
+        compression,
+        "-o",
+        output_file,
+    ]
+    subprocess.run(cmd, check=True)  # nosec B603
+    assert os.path.exists(output_file)
+    assert os.path.getsize(output_file) > 0
+
+    if compression == "zip":
+        with zipfile.ZipFile(output_file, "r") as zf:
+            content = zf.read(zf.namelist()[0]).decode()
+    else:
+        with _compression_opener[compression](output_file) as f:
+            content = f.read()
+    assert ";" in content
+
+
+@pytest.mark.parametrize(
+    "ext",
+    [".gz", ".bz2", ".xz", ".zip", ".zst"],
+)
+def test_alifestd_as_newick_polars_cli_extension_without_flag(ext: str):
+    output_file = (
+        "/tmp/phyloframe-as_newick_polars_cli-"  # nosec B108
+        f"ext-mismatch{ext}"
+    )
+    cmd = [
+        "python3",
+        "-m",
+        "phyloframe.legacy._alifestd_as_newick_polars",
+        "--input-file",
+        f"{assets}/example-standard-toy-asexual-phylogeny.csv",
+        "-o",
+        output_file,
+    ]
+    result = subprocess.run(cmd, capture_output=True)  # nosec B603
+    assert result.returncode != 0


### PR DESCRIPTION
## Summary
This PR adds support for writing output files with various compression formats (gzip, bz2, xz, zip) to the phyloframe library. It introduces reusable utility functions for handling compressed output and integrates them into the existing CLI tools.

## Key Changes

- **New utility module `_write_text_with_compression.py`**: Provides a single function to write text to files with optional compression support. Handles gzip, bz2, xz, and zip formats from the Python standard library. Includes validation to ensure file extensions match the requested compression format.

- **New utility module `_add_compression_cli_arg.py`**: Provides a reusable function to add a `--compression` argument to argparse parsers with consistent choices and help text.

- **Updated CLI tools**: Integrated compression support into:
  - `_alifestd_as_newick_asexual.py`
  - `_alifestd_as_newick_polars.py`
  
  Both now accept a `--compression` flag and use the new utility functions to write compressed output.

- **Comprehensive test coverage**: Added two new test modules:
  - `test_write_text_with_compression.py`: Tests all compression formats, error handling for extension mismatches, and edge cases (empty files)
  - `test_alifestd_as_newick_polars_cli.py`: Integration tests for the CLI with compression support
  - Extended `test_alifestd_as_newick_asexual_cli.py`: Added compression and extension validation tests

## Implementation Details

- The `write_text_with_compression()` function validates that file extensions match the compression format to prevent user confusion (e.g., `.gz` file without gzip compression)
- For zip files, the member name is derived from the file stem (filename without extension)
- All compression operations use text mode (`"wt"`) for consistency
- Logging is included to inform users of the compression format being used
- The implementation follows the existing code style and patterns in the phyloframe library

https://claude.ai/code/session_01RDhkH2MwU7SmZaXBaFAU5i