### PR TITLE
Add leaf-split and edge-split tree generation functions

### DIFF
--- a/phyloframe/legacy/__init__.pyi
+++ b/phyloframe/legacy/__init__.pyi
@@ -272,8 +272,12 @@ from ._alifestd_make_balanced_bifurcating_polars import (
 )
 from ._alifestd_make_comb import alifestd_make_comb
 from ._alifestd_make_comb_polars import alifestd_make_comb_polars
+from ._alifestd_make_edge_split import alifestd_make_edge_split
+from ._alifestd_make_edge_split_polars import alifestd_make_edge_split_polars
 from ._alifestd_make_empty import alifestd_make_empty
 from ._alifestd_make_empty_polars import alifestd_make_empty_polars
+from ._alifestd_make_leaf_split import alifestd_make_leaf_split
+from ._alifestd_make_leaf_split_polars import alifestd_make_leaf_split_polars
 from ._alifestd_make_star import alifestd_make_star
 from ._alifestd_make_star_polars import alifestd_make_star_polars
 from ._alifestd_mark_ancestor_origin_time_asexual import (
@@ -777,8 +781,12 @@ __all__ = [
     "alifestd_make_balanced_bifurcating_polars",
     "alifestd_make_comb",
     "alifestd_make_comb_polars",
+    "alifestd_make_edge_split",
+    "alifestd_make_edge_split_polars",
     "alifestd_make_empty",
     "alifestd_make_empty_polars",
+    "alifestd_make_leaf_split",
+    "alifestd_make_leaf_split_polars",
     "alifestd_make_star",
     "alifestd_make_star_polars",
     "alifestd_mark_ancestor_origin_time_asexual",

--- a/phyloframe/legacy/_alifestd_make_edge_split.py
+++ b/phyloframe/legacy/_alifestd_make_edge_split.py
@@ -17,8 +17,9 @@ def _make_edge_split_fast_path(n_leaves: int):
     if n_leaves == 1:
         return ids, ancestor_ids
 
+    # numba's np.random.randint does not broadcast over array-valued high
     victims = 1 + (
-        np.random.random(n_leaves - 2) * (2 + 2 * np.arange(n_leaves - 2))
+        np.random.random(size=n_leaves - 2) * (2 + 2 * np.arange(n_leaves - 2))
     ).astype(np.int64)
 
     for i, victim in enumerate(victims):

--- a/phyloframe/legacy/_alifestd_make_edge_split.py
+++ b/phyloframe/legacy/_alifestd_make_edge_split.py
@@ -1,14 +1,16 @@
+import typing
+
 import numpy as np
 import pandas as pd
 
 from .._auxlib._jit import jit
+from .._auxlib._with_rng_state_context import with_rng_state_context
 from ._alifestd_make_empty import alifestd_make_empty
 
 
 @jit(nopython=True)
-def _make_edge_split_fast_path(n_leaves: int, seed: int):
+def _make_edge_split_fast_path(n_leaves: int):
     """Build id and ancestor_id arrays for an edge-split (PDA) tree."""
-    np.random.seed(seed)
     n_nodes = 2 * n_leaves - 1
     ids = np.arange(n_nodes, dtype=np.int64)
     ancestor_ids = np.empty(n_nodes, dtype=np.int64)
@@ -32,7 +34,10 @@ def _make_edge_split_fast_path(n_leaves: int, seed: int):
     return ids, ancestor_ids
 
 
-def alifestd_make_edge_split(n_leaves: int, seed: int) -> pd.DataFrame:
+def alifestd_make_edge_split(
+    n_leaves: int,
+    seed: typing.Optional[int] = None,
+) -> pd.DataFrame:
     """Build a random bifurcating tree via edge-split (PDA) sampling.
 
     At each step, a uniformly chosen existing edge is split by inserting
@@ -44,7 +49,7 @@ def alifestd_make_edge_split(n_leaves: int, seed: int) -> pd.DataFrame:
     ----------
     n_leaves : int
         Number of leaf nodes in the resulting tree.
-    seed : int
+    seed : int, optional
         Integer seed for deterministic behavior.
 
     Returns
@@ -63,7 +68,13 @@ def alifestd_make_edge_split(n_leaves: int, seed: int) -> pd.DataFrame:
     elif n_leaves == 0:
         return alifestd_make_empty()
 
-    ids, ancestor_ids = _make_edge_split_fast_path(n_leaves, seed)
+    impl = (
+        with_rng_state_context(seed)(_make_edge_split_fast_path)
+        if seed is not None
+        else _make_edge_split_fast_path
+    )
+
+    ids, ancestor_ids = impl(n_leaves)
     ancestor_lists = [
         "[None]" if i == a else f"[{a}]" for i, a in zip(ids, ancestor_ids)
     ]

--- a/phyloframe/legacy/_alifestd_make_edge_split.py
+++ b/phyloframe/legacy/_alifestd_make_edge_split.py
@@ -13,17 +13,17 @@ def _make_edge_split_fast_path(n_leaves: int):
     """Build id and ancestor_id arrays for an edge-split (PDA) tree."""
     n_nodes = 2 * n_leaves - 1
     ids = np.arange(n_nodes, dtype=np.int64)
-    ancestor_ids = np.empty(n_nodes, dtype=np.int64)
-    ancestor_ids[0] = 0
+    ancestor_ids = np.zeros(n_nodes, dtype=np.int64)
     if n_leaves == 1:
         return ids, ancestor_ids
 
-    ancestor_ids[1] = 0
-    ancestor_ids[2] = 0
+    victims = 1 + (
+        np.random.random(n_leaves - 2) * (2 + 2 * np.arange(n_leaves - 2))
+    ).astype(np.int64)
 
-    for new_internal in range(3, n_nodes, 2):
-        victim = np.random.randint(1, new_internal)
+    for i, new_internal in enumerate(range(3, n_nodes, 2)):
         new_leaf = new_internal + 1
+        victim = victims[i]
         ancestor_ids[new_internal] = ancestor_ids[victim]
         ancestor_ids[victim] = new_internal
         ancestor_ids[new_leaf] = new_internal

--- a/phyloframe/legacy/_alifestd_make_edge_split.py
+++ b/phyloframe/legacy/_alifestd_make_edge_split.py
@@ -21,12 +21,9 @@ def _make_edge_split_fast_path(n_leaves: int):
     ancestor_ids[1] = 0
     ancestor_ids[2] = 0
 
-    next_id = 3
-    for _ in range(n_leaves - 2):
-        victim = np.random.randint(1, next_id)
-        new_internal = next_id
-        new_leaf = next_id + 1
-        next_id += 2
+    for new_internal in range(3, n_nodes, 2):
+        victim = np.random.randint(1, new_internal)
+        new_leaf = new_internal + 1
         ancestor_ids[new_internal] = ancestor_ids[victim]
         ancestor_ids[victim] = new_internal
         ancestor_ids[new_leaf] = new_internal

--- a/phyloframe/legacy/_alifestd_make_edge_split.py
+++ b/phyloframe/legacy/_alifestd_make_edge_split.py
@@ -3,6 +3,7 @@ import typing
 import numpy as np
 import pandas as pd
 
+from .._auxlib._build_children_csr import build_children_csr
 from .._auxlib._jit import jit
 from .._auxlib._with_rng_state_context import with_rng_state_context
 from ._alifestd_make_empty import alifestd_make_empty
@@ -29,7 +30,34 @@ def _make_edge_split_fast_path(n_leaves: int):
         ancestor_ids[victim] = new_internal
         ancestor_ids[new_leaf] = new_internal
 
-    return ids, ancestor_ids
+    # relabel via BFS from root so that parent ids precede child ids
+    num_children = np.zeros(n_nodes, dtype=np.int64)
+    for i in range(1, n_nodes):
+        num_children[ancestor_ids[i]] += 1
+    child_start, csr_children = build_children_csr(ancestor_ids, num_children)
+
+    old_to_new = np.empty(n_nodes, dtype=np.int64)
+    old_to_new[0] = 0
+    queue = np.empty(n_nodes, dtype=np.int64)
+    queue[0] = 0
+    head = 0
+    tail = 1
+    next_id = 1
+    while head < tail:
+        old = queue[head]
+        head += 1
+        for k in range(child_start[old], child_start[old + 1]):
+            child_old = csr_children[k]
+            old_to_new[child_old] = next_id
+            queue[tail] = child_old
+            tail += 1
+            next_id += 1
+
+    new_ancestor_ids = np.empty(n_nodes, dtype=np.int64)
+    for old in range(n_nodes):
+        new_ancestor_ids[old_to_new[old]] = old_to_new[ancestor_ids[old]]
+
+    return ids, new_ancestor_ids
 
 
 def alifestd_make_edge_split(

--- a/phyloframe/legacy/_alifestd_make_edge_split.py
+++ b/phyloframe/legacy/_alifestd_make_edge_split.py
@@ -1,0 +1,70 @@
+import numpy as np
+import pandas as pd
+
+from .._auxlib._jit import jit
+from ._alifestd_make_empty import alifestd_make_empty
+
+
+@jit(nopython=True)
+def _make_edge_split_fast_path(n_leaves: int, seed: int):
+    """Build id and ancestor_id arrays for an edge-split (PDA) tree."""
+    np.random.seed(seed)
+    n_nodes = 2 * n_leaves - 1
+    ids = np.arange(n_nodes, dtype=np.int64)
+    ancestor_ids = np.empty(n_nodes, dtype=np.int64)
+    ancestor_ids[0] = 0
+    if n_leaves == 1:
+        return ids, ancestor_ids
+
+    ancestor_ids[1] = 0
+    ancestor_ids[2] = 0
+
+    next_id = 3
+    for _ in range(n_leaves - 2):
+        victim = np.random.randint(1, next_id)
+        new_internal = next_id
+        new_leaf = next_id + 1
+        next_id += 2
+        ancestor_ids[new_internal] = ancestor_ids[victim]
+        ancestor_ids[victim] = new_internal
+        ancestor_ids[new_leaf] = new_internal
+
+    return ids, ancestor_ids
+
+
+def alifestd_make_edge_split(n_leaves: int, seed: int) -> pd.DataFrame:
+    """Build a random bifurcating tree via edge-split (PDA) sampling.
+
+    At each step, a uniformly chosen existing edge is split by inserting
+    a new internal node, with a new leaf attached as its sibling. This
+    produces samples from the Proportional-to-Distinguishable-Arrangements
+    (PDA) distribution over rooted bifurcating tree shapes.
+
+    Parameters
+    ----------
+    n_leaves : int
+        Number of leaf nodes in the resulting tree.
+    seed : int
+        Integer seed for deterministic behavior.
+
+    Returns
+    -------
+    pd.DataFrame
+        Alife-standard phylogeny dataframe with 'id' and 'ancestor_list'
+        columns.
+
+    Raises
+    ------
+    ValueError
+        If n_leaves is negative.
+    """
+    if n_leaves < 0:
+        raise ValueError("n_leaves must be non-negative")
+    elif n_leaves == 0:
+        return alifestd_make_empty()
+
+    ids, ancestor_ids = _make_edge_split_fast_path(n_leaves, seed)
+    ancestor_lists = [
+        "[None]" if i == a else f"[{a}]" for i, a in zip(ids, ancestor_ids)
+    ]
+    return pd.DataFrame({"id": ids, "ancestor_list": ancestor_lists})

--- a/phyloframe/legacy/_alifestd_make_edge_split.py
+++ b/phyloframe/legacy/_alifestd_make_edge_split.py
@@ -21,9 +21,9 @@ def _make_edge_split_fast_path(n_leaves: int):
         np.random.random(n_leaves - 2) * (2 + 2 * np.arange(n_leaves - 2))
     ).astype(np.int64)
 
-    for i, new_internal in enumerate(range(3, n_nodes, 2)):
+    for i, victim in enumerate(victims):
+        new_internal = 3 + 2 * i
         new_leaf = new_internal + 1
-        victim = victims[i]
         ancestor_ids[new_internal] = ancestor_ids[victim]
         ancestor_ids[victim] = new_internal
         ancestor_ids[new_leaf] = new_internal

--- a/phyloframe/legacy/_alifestd_make_edge_split.py
+++ b/phyloframe/legacy/_alifestd_make_edge_split.py
@@ -3,7 +3,6 @@ import typing
 import numpy as np
 import pandas as pd
 
-from .._auxlib._build_children_csr import build_children_csr
 from .._auxlib._jit import jit
 from .._auxlib._with_rng_state_context import with_rng_state_context
 from ._alifestd_make_empty import alifestd_make_empty
@@ -30,34 +29,7 @@ def _make_edge_split_fast_path(n_leaves: int):
         ancestor_ids[victim] = new_internal
         ancestor_ids[new_leaf] = new_internal
 
-    # relabel via BFS from root so that parent ids precede child ids
-    num_children = np.zeros(n_nodes, dtype=np.int64)
-    for i in range(1, n_nodes):
-        num_children[ancestor_ids[i]] += 1
-    child_start, csr_children = build_children_csr(ancestor_ids, num_children)
-
-    old_to_new = np.empty(n_nodes, dtype=np.int64)
-    old_to_new[0] = 0
-    queue = np.empty(n_nodes, dtype=np.int64)
-    queue[0] = 0
-    head = 0
-    tail = 1
-    next_id = 1
-    while head < tail:
-        old = queue[head]
-        head += 1
-        for k in range(child_start[old], child_start[old + 1]):
-            child_old = csr_children[k]
-            old_to_new[child_old] = next_id
-            queue[tail] = child_old
-            tail += 1
-            next_id += 1
-
-    new_ancestor_ids = np.empty(n_nodes, dtype=np.int64)
-    for old in range(n_nodes):
-        new_ancestor_ids[old_to_new[old]] = old_to_new[ancestor_ids[old]]
-
-    return ids, new_ancestor_ids
+    return ids, ancestor_ids
 
 
 def alifestd_make_edge_split(
@@ -70,6 +42,11 @@ def alifestd_make_edge_split(
     a new internal node, with a new leaf attached as its sibling. This
     produces samples from the Proportional-to-Distinguishable-Arrangements
     (PDA) distribution over rooted bifurcating tree shapes.
+
+    Ids are contiguous but not topologically sorted; inserted internal
+    nodes may have ids greater than some of their descendants. Pass the
+    result through ``alifestd_topological_sort`` if topological id order
+    is needed.
 
     Parameters
     ----------

--- a/phyloframe/legacy/_alifestd_make_edge_split_polars.py
+++ b/phyloframe/legacy/_alifestd_make_edge_split_polars.py
@@ -1,0 +1,36 @@
+import polars as pl
+
+from ._alifestd_make_edge_split import _make_edge_split_fast_path
+from ._alifestd_make_empty_polars import alifestd_make_empty_polars
+
+
+def alifestd_make_edge_split_polars(
+    n_leaves: int,
+    seed: int,
+) -> pl.DataFrame:
+    """Build a random bifurcating tree via edge-split (PDA) sampling.
+
+    At each step, a uniformly chosen existing edge is split by inserting
+    a new internal node, with a new leaf attached as its sibling. This
+    produces samples from the Proportional-to-Distinguishable-Arrangements
+    (PDA) distribution over rooted bifurcating tree shapes.
+
+    Parameters
+    ----------
+    n_leaves : int
+        Number of leaf nodes in the resulting tree.
+    seed : int
+        Integer seed for deterministic behavior.
+
+    Returns
+    -------
+    pl.DataFrame
+        Phylogeny dataframe with 'id' and 'ancestor_id' columns.
+    """
+    if n_leaves < 0:
+        raise ValueError("n_leaves must be non-negative")
+    elif n_leaves == 0:
+        return alifestd_make_empty_polars(ancestor_id=True)
+
+    ids, ancestor_ids = _make_edge_split_fast_path(n_leaves, seed)
+    return pl.DataFrame({"id": ids, "ancestor_id": ancestor_ids})

--- a/phyloframe/legacy/_alifestd_make_edge_split_polars.py
+++ b/phyloframe/legacy/_alifestd_make_edge_split_polars.py
@@ -18,6 +18,11 @@ def alifestd_make_edge_split_polars(
     produces samples from the Proportional-to-Distinguishable-Arrangements
     (PDA) distribution over rooted bifurcating tree shapes.
 
+    Ids are contiguous but not topologically sorted; inserted internal
+    nodes may have ids greater than some of their descendants. Pass the
+    result through ``alifestd_topological_sort_polars`` if topological
+    id order is needed.
+
     Parameters
     ----------
     n_leaves : int

--- a/phyloframe/legacy/_alifestd_make_edge_split_polars.py
+++ b/phyloframe/legacy/_alifestd_make_edge_split_polars.py
@@ -1,12 +1,15 @@
+import typing
+
 import polars as pl
 
+from .._auxlib._with_rng_state_context import with_rng_state_context
 from ._alifestd_make_edge_split import _make_edge_split_fast_path
 from ._alifestd_make_empty_polars import alifestd_make_empty_polars
 
 
 def alifestd_make_edge_split_polars(
     n_leaves: int,
-    seed: int,
+    seed: typing.Optional[int] = None,
 ) -> pl.DataFrame:
     """Build a random bifurcating tree via edge-split (PDA) sampling.
 
@@ -19,7 +22,7 @@ def alifestd_make_edge_split_polars(
     ----------
     n_leaves : int
         Number of leaf nodes in the resulting tree.
-    seed : int
+    seed : int, optional
         Integer seed for deterministic behavior.
 
     Returns
@@ -32,5 +35,11 @@ def alifestd_make_edge_split_polars(
     elif n_leaves == 0:
         return alifestd_make_empty_polars(ancestor_id=True)
 
-    ids, ancestor_ids = _make_edge_split_fast_path(n_leaves, seed)
+    impl = (
+        with_rng_state_context(seed)(_make_edge_split_fast_path)
+        if seed is not None
+        else _make_edge_split_fast_path
+    )
+
+    ids, ancestor_ids = impl(n_leaves)
     return pl.DataFrame({"id": ids, "ancestor_id": ancestor_ids})

--- a/phyloframe/legacy/_alifestd_make_leaf_split.py
+++ b/phyloframe/legacy/_alifestd_make_leaf_split.py
@@ -20,20 +20,16 @@ def _make_leaf_split_fast_path(n_leaves: int):
 
     leaves = np.empty(n_leaves, dtype=np.int64)
     leaves[0] = 0
-    n_current_leaves = 1
 
-    next_id = 1
-    for _ in range(n_leaves - 1):
+    for left in range(1, n_nodes, 2):
+        n_current_leaves = (left + 1) // 2
         idx = np.random.randint(0, n_current_leaves)
         parent = leaves[idx]
-        left = next_id
-        right = next_id + 1
-        next_id += 2
+        right = left + 1
         ancestor_ids[left] = parent
         ancestor_ids[right] = parent
         leaves[idx] = left
         leaves[n_current_leaves] = right
-        n_current_leaves += 1
 
     return ids, ancestor_ids
 

--- a/phyloframe/legacy/_alifestd_make_leaf_split.py
+++ b/phyloframe/legacy/_alifestd_make_leaf_split.py
@@ -18,17 +18,17 @@ def _make_leaf_split_fast_path(n_leaves: int):
         return ids, ancestor_ids
 
     leaves = np.zeros(n_leaves, dtype=np.int64)
-    random_indices = (
-        np.random.random(n_leaves - 1) * np.arange(1, n_leaves)
-    ).astype(np.int64)
+    victims = (np.random.random(n_leaves - 1) * np.arange(1, n_leaves)).astype(
+        np.int64
+    )
 
-    for i, left in enumerate(range(1, n_nodes, 2)):
+    for i, victim in enumerate(victims):
+        left = 1 + 2 * i
         right = left + 1
-        idx = random_indices[i]
-        parent = leaves[idx]
+        parent = leaves[victim]
         ancestor_ids[left] = parent
         ancestor_ids[right] = parent
-        leaves[idx] = left
+        leaves[victim] = left
         leaves[i + 1] = right
 
     return ids, ancestor_ids

--- a/phyloframe/legacy/_alifestd_make_leaf_split.py
+++ b/phyloframe/legacy/_alifestd_make_leaf_split.py
@@ -1,14 +1,16 @@
+import typing
+
 import numpy as np
 import pandas as pd
 
 from .._auxlib._jit import jit
+from .._auxlib._with_rng_state_context import with_rng_state_context
 from ._alifestd_make_empty import alifestd_make_empty
 
 
 @jit(nopython=True)
-def _make_leaf_split_fast_path(n_leaves: int, seed: int):
+def _make_leaf_split_fast_path(n_leaves: int):
     """Build id and ancestor_id arrays for a leaf-split (Yule) tree."""
-    np.random.seed(seed)
     n_nodes = 2 * n_leaves - 1
     ids = np.arange(n_nodes, dtype=np.int64)
     ancestor_ids = np.empty(n_nodes, dtype=np.int64)
@@ -36,7 +38,10 @@ def _make_leaf_split_fast_path(n_leaves: int, seed: int):
     return ids, ancestor_ids
 
 
-def alifestd_make_leaf_split(n_leaves: int, seed: int) -> pd.DataFrame:
+def alifestd_make_leaf_split(
+    n_leaves: int,
+    seed: typing.Optional[int] = None,
+) -> pd.DataFrame:
     """Build a random bifurcating tree via leaf-split (Yule) sampling.
 
     At each step, a uniformly chosen leaf is replaced by an internal node
@@ -47,7 +52,7 @@ def alifestd_make_leaf_split(n_leaves: int, seed: int) -> pd.DataFrame:
     ----------
     n_leaves : int
         Number of leaf nodes in the resulting tree.
-    seed : int
+    seed : int, optional
         Integer seed for deterministic behavior.
 
     Returns
@@ -66,7 +71,13 @@ def alifestd_make_leaf_split(n_leaves: int, seed: int) -> pd.DataFrame:
     elif n_leaves == 0:
         return alifestd_make_empty()
 
-    ids, ancestor_ids = _make_leaf_split_fast_path(n_leaves, seed)
+    impl = (
+        with_rng_state_context(seed)(_make_leaf_split_fast_path)
+        if seed is not None
+        else _make_leaf_split_fast_path
+    )
+
+    ids, ancestor_ids = impl(n_leaves)
     ancestor_lists = [
         "[None]" if i == a else f"[{a}]" for i, a in zip(ids, ancestor_ids)
     ]

--- a/phyloframe/legacy/_alifestd_make_leaf_split.py
+++ b/phyloframe/legacy/_alifestd_make_leaf_split.py
@@ -1,0 +1,73 @@
+import numpy as np
+import pandas as pd
+
+from .._auxlib._jit import jit
+from ._alifestd_make_empty import alifestd_make_empty
+
+
+@jit(nopython=True)
+def _make_leaf_split_fast_path(n_leaves: int, seed: int):
+    """Build id and ancestor_id arrays for a leaf-split (Yule) tree."""
+    np.random.seed(seed)
+    n_nodes = 2 * n_leaves - 1
+    ids = np.arange(n_nodes, dtype=np.int64)
+    ancestor_ids = np.empty(n_nodes, dtype=np.int64)
+    ancestor_ids[0] = 0
+    if n_leaves == 1:
+        return ids, ancestor_ids
+
+    leaves = np.empty(n_leaves, dtype=np.int64)
+    leaves[0] = 0
+    n_current_leaves = 1
+
+    next_id = 1
+    for _ in range(n_leaves - 1):
+        idx = np.random.randint(0, n_current_leaves)
+        parent = leaves[idx]
+        left = next_id
+        right = next_id + 1
+        next_id += 2
+        ancestor_ids[left] = parent
+        ancestor_ids[right] = parent
+        leaves[idx] = left
+        leaves[n_current_leaves] = right
+        n_current_leaves += 1
+
+    return ids, ancestor_ids
+
+
+def alifestd_make_leaf_split(n_leaves: int, seed: int) -> pd.DataFrame:
+    """Build a random bifurcating tree via leaf-split (Yule) sampling.
+
+    At each step, a uniformly chosen leaf is replaced by an internal node
+    with two new leaf children. This produces samples from the Yule (pure-
+    birth) distribution over rooted bifurcating tree shapes.
+
+    Parameters
+    ----------
+    n_leaves : int
+        Number of leaf nodes in the resulting tree.
+    seed : int
+        Integer seed for deterministic behavior.
+
+    Returns
+    -------
+    pd.DataFrame
+        Alife-standard phylogeny dataframe with 'id' and 'ancestor_list'
+        columns.
+
+    Raises
+    ------
+    ValueError
+        If n_leaves is negative.
+    """
+    if n_leaves < 0:
+        raise ValueError("n_leaves must be non-negative")
+    elif n_leaves == 0:
+        return alifestd_make_empty()
+
+    ids, ancestor_ids = _make_leaf_split_fast_path(n_leaves, seed)
+    ancestor_lists = [
+        "[None]" if i == a else f"[{a}]" for i, a in zip(ids, ancestor_ids)
+    ]
+    return pd.DataFrame({"id": ids, "ancestor_list": ancestor_lists})

--- a/phyloframe/legacy/_alifestd_make_leaf_split.py
+++ b/phyloframe/legacy/_alifestd_make_leaf_split.py
@@ -13,23 +13,23 @@ def _make_leaf_split_fast_path(n_leaves: int):
     """Build id and ancestor_id arrays for a leaf-split (Yule) tree."""
     n_nodes = 2 * n_leaves - 1
     ids = np.arange(n_nodes, dtype=np.int64)
-    ancestor_ids = np.empty(n_nodes, dtype=np.int64)
-    ancestor_ids[0] = 0
+    ancestor_ids = np.zeros(n_nodes, dtype=np.int64)
     if n_leaves == 1:
         return ids, ancestor_ids
 
-    leaves = np.empty(n_leaves, dtype=np.int64)
-    leaves[0] = 0
+    leaves = np.zeros(n_leaves, dtype=np.int64)
+    random_indices = (
+        np.random.random(n_leaves - 1) * np.arange(1, n_leaves)
+    ).astype(np.int64)
 
-    for left in range(1, n_nodes, 2):
-        n_current_leaves = (left + 1) // 2
-        idx = np.random.randint(0, n_current_leaves)
-        parent = leaves[idx]
+    for i, left in enumerate(range(1, n_nodes, 2)):
         right = left + 1
+        idx = random_indices[i]
+        parent = leaves[idx]
         ancestor_ids[left] = parent
         ancestor_ids[right] = parent
         leaves[idx] = left
-        leaves[n_current_leaves] = right
+        leaves[i + 1] = right
 
     return ids, ancestor_ids
 

--- a/phyloframe/legacy/_alifestd_make_leaf_split.py
+++ b/phyloframe/legacy/_alifestd_make_leaf_split.py
@@ -18,9 +18,10 @@ def _make_leaf_split_fast_path(n_leaves: int):
         return ids, ancestor_ids
 
     leaves = np.zeros(n_leaves, dtype=np.int64)
-    victims = (np.random.random(n_leaves - 1) * np.arange(1, n_leaves)).astype(
-        np.int64
-    )
+    # numba's np.random.randint does not broadcast over array-valued high
+    victims = (
+        np.random.random(size=n_leaves - 1) * np.arange(1, n_leaves)
+    ).astype(np.int64)
 
     for i, victim in enumerate(victims):
         left = 1 + 2 * i

--- a/phyloframe/legacy/_alifestd_make_leaf_split_polars.py
+++ b/phyloframe/legacy/_alifestd_make_leaf_split_polars.py
@@ -1,12 +1,15 @@
+import typing
+
 import polars as pl
 
+from .._auxlib._with_rng_state_context import with_rng_state_context
 from ._alifestd_make_empty_polars import alifestd_make_empty_polars
 from ._alifestd_make_leaf_split import _make_leaf_split_fast_path
 
 
 def alifestd_make_leaf_split_polars(
     n_leaves: int,
-    seed: int,
+    seed: typing.Optional[int] = None,
 ) -> pl.DataFrame:
     """Build a random bifurcating tree via leaf-split (Yule) sampling.
 
@@ -18,7 +21,7 @@ def alifestd_make_leaf_split_polars(
     ----------
     n_leaves : int
         Number of leaf nodes in the resulting tree.
-    seed : int
+    seed : int, optional
         Integer seed for deterministic behavior.
 
     Returns
@@ -31,5 +34,11 @@ def alifestd_make_leaf_split_polars(
     elif n_leaves == 0:
         return alifestd_make_empty_polars(ancestor_id=True)
 
-    ids, ancestor_ids = _make_leaf_split_fast_path(n_leaves, seed)
+    impl = (
+        with_rng_state_context(seed)(_make_leaf_split_fast_path)
+        if seed is not None
+        else _make_leaf_split_fast_path
+    )
+
+    ids, ancestor_ids = impl(n_leaves)
     return pl.DataFrame({"id": ids, "ancestor_id": ancestor_ids})

--- a/phyloframe/legacy/_alifestd_make_leaf_split_polars.py
+++ b/phyloframe/legacy/_alifestd_make_leaf_split_polars.py
@@ -1,0 +1,35 @@
+import polars as pl
+
+from ._alifestd_make_empty_polars import alifestd_make_empty_polars
+from ._alifestd_make_leaf_split import _make_leaf_split_fast_path
+
+
+def alifestd_make_leaf_split_polars(
+    n_leaves: int,
+    seed: int,
+) -> pl.DataFrame:
+    """Build a random bifurcating tree via leaf-split (Yule) sampling.
+
+    At each step, a uniformly chosen leaf is replaced by an internal node
+    with two new leaf children. This produces samples from the Yule (pure-
+    birth) distribution over rooted bifurcating tree shapes.
+
+    Parameters
+    ----------
+    n_leaves : int
+        Number of leaf nodes in the resulting tree.
+    seed : int
+        Integer seed for deterministic behavior.
+
+    Returns
+    -------
+    pl.DataFrame
+        Phylogeny dataframe with 'id' and 'ancestor_id' columns.
+    """
+    if n_leaves < 0:
+        raise ValueError("n_leaves must be non-negative")
+    elif n_leaves == 0:
+        return alifestd_make_empty_polars(ancestor_id=True)
+
+    ids, ancestor_ids = _make_leaf_split_fast_path(n_leaves, seed)
+    return pl.DataFrame({"id": ids, "ancestor_id": ancestor_ids})

--- a/tests/test_phyloframe/test_legacy/test_alifestd_make_edge_split.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_make_edge_split.py
@@ -3,6 +3,7 @@ import pytest
 
 from phyloframe.legacy import (
     alifestd_find_leaf_ids,
+    alifestd_is_strictly_bifurcating_asexual,
     alifestd_make_edge_split,
     alifestd_validate,
 )
@@ -38,13 +39,8 @@ def test_validates(n_leaves: int, seed: int):
 
 @pytest.mark.parametrize("n_leaves", [2, 3, 4, 5, 8, 16])
 def test_bifurcating_structure(n_leaves: int):
-    """Every internal node should have exactly 2 children."""
     df = alifestd_make_edge_split(n_leaves, seed=42)
-    leaf_ids = set(alifestd_find_leaf_ids(df))
-    for _, row in df.iterrows():
-        if row["id"] not in leaf_ids:
-            children = df[df["ancestor_list"] == f"[{row['id']}]"]
-            assert len(children) == 2
+    assert alifestd_is_strictly_bifurcating_asexual(df)
 
 
 @pytest.mark.parametrize("n_leaves", [1, 2, 3, 4, 5, 8])

--- a/tests/test_phyloframe/test_legacy/test_alifestd_make_edge_split.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_make_edge_split.py
@@ -71,6 +71,31 @@ def test_different_seeds_differ(n_leaves: int):
     assert not a.equals(b)
 
 
+@pytest.mark.parametrize("n_leaves", [5, 8, 16])
+def test_no_seed(n_leaves: int):
+    """Omitting seed should still produce a valid tree."""
+    df = alifestd_make_edge_split(n_leaves)
+    assert len(df) == 2 * n_leaves - 1
+
+
+def test_seed_does_not_leak_rng_state():
+    """Using a seed should not perturb outer RNG state."""
+    import random
+
+    import numpy as np
+
+    random.seed(0)
+    np.random.seed(0)
+    expected_py = random.random()
+    expected_np = np.random.random()
+
+    random.seed(0)
+    np.random.seed(0)
+    alifestd_make_edge_split(16, seed=42)
+    assert random.random() == expected_py
+    assert np.random.random() == expected_np
+
+
 def test_zero_leaves():
     df = alifestd_make_edge_split(0, seed=0)
     assert len(df) == 0

--- a/tests/test_phyloframe/test_legacy/test_alifestd_make_edge_split.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_make_edge_split.py
@@ -1,0 +1,88 @@
+import pandas as pd
+import pytest
+
+from phyloframe.legacy import (
+    alifestd_find_leaf_ids,
+    alifestd_make_edge_split,
+    alifestd_validate,
+)
+
+
+@pytest.mark.parametrize("n_leaves", [2, 3, 4, 5, 8, 16])
+def test_node_count(n_leaves: int):
+    """Total node count should be 2*n_leaves - 1."""
+    df = alifestd_make_edge_split(n_leaves, seed=42)
+    assert len(df) == 2 * n_leaves - 1
+
+
+@pytest.mark.parametrize("n_leaves", [2, 3, 4, 5, 8, 16])
+def test_leaf_count(n_leaves: int):
+    df = alifestd_make_edge_split(n_leaves, seed=42)
+    leaf_ids = [*alifestd_find_leaf_ids(df)]
+    assert len(leaf_ids) == n_leaves
+
+
+@pytest.mark.parametrize("n_leaves", [2, 3, 4, 5, 8, 16])
+def test_contiguous_ids(n_leaves: int):
+    """IDs should be contiguous starting from 0."""
+    df = alifestd_make_edge_split(n_leaves, seed=42)
+    assert list(df["id"]) == list(range(len(df)))
+
+
+@pytest.mark.parametrize("n_leaves", [1, 2, 3, 4, 5, 8, 16])
+@pytest.mark.parametrize("seed", [0, 1, 42, 12345])
+def test_validates(n_leaves: int, seed: int):
+    df = alifestd_make_edge_split(n_leaves, seed=seed)
+    assert alifestd_validate(df)
+
+
+@pytest.mark.parametrize("n_leaves", [2, 3, 4, 5, 8, 16])
+def test_bifurcating_structure(n_leaves: int):
+    """Every internal node should have exactly 2 children."""
+    df = alifestd_make_edge_split(n_leaves, seed=42)
+    leaf_ids = set(alifestd_find_leaf_ids(df))
+    for _, row in df.iterrows():
+        if row["id"] not in leaf_ids:
+            children = df[df["ancestor_list"] == f"[{row['id']}]"]
+            assert len(children) == 2
+
+
+@pytest.mark.parametrize("n_leaves", [1, 2, 3, 4, 5, 8])
+def test_returns_dataframe(n_leaves: int):
+    result = alifestd_make_edge_split(n_leaves, seed=7)
+    assert isinstance(result, pd.DataFrame)
+    assert "id" in result.columns
+    assert "ancestor_list" in result.columns
+
+
+@pytest.mark.parametrize("n_leaves", [2, 3, 4, 5, 8, 16])
+@pytest.mark.parametrize("seed", [0, 1, 42, 12345])
+def test_deterministic(n_leaves: int, seed: int):
+    a = alifestd_make_edge_split(n_leaves, seed=seed)
+    b = alifestd_make_edge_split(n_leaves, seed=seed)
+    assert a.equals(b)
+
+
+@pytest.mark.parametrize("n_leaves", [5, 8, 16])
+def test_different_seeds_differ(n_leaves: int):
+    """Different seeds should usually produce different trees."""
+    a = alifestd_make_edge_split(n_leaves, seed=1)
+    b = alifestd_make_edge_split(n_leaves, seed=2)
+    assert not a.equals(b)
+
+
+def test_zero_leaves():
+    df = alifestd_make_edge_split(0, seed=0)
+    assert len(df) == 0
+    assert isinstance(df, pd.DataFrame)
+
+
+def test_single_leaf():
+    df = alifestd_make_edge_split(1, seed=0)
+    assert len(df) == 1
+    assert df.iloc[0]["ancestor_list"] == "[None]"
+
+
+def test_negative_leaves():
+    with pytest.raises(ValueError):
+        alifestd_make_edge_split(-1, seed=0)

--- a/tests/test_phyloframe/test_legacy/test_alifestd_make_edge_split.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_make_edge_split.py
@@ -4,7 +4,6 @@ import pytest
 from phyloframe.legacy import (
     alifestd_find_leaf_ids,
     alifestd_is_strictly_bifurcating_asexual,
-    alifestd_is_topologically_sorted,
     alifestd_make_edge_split,
     alifestd_validate,
 )
@@ -42,12 +41,6 @@ def test_validates(n_leaves: int, seed: int):
 def test_bifurcating_structure(n_leaves: int):
     df = alifestd_make_edge_split(n_leaves, seed=42)
     assert alifestd_is_strictly_bifurcating_asexual(df)
-
-
-@pytest.mark.parametrize("n_leaves", [2, 3, 4, 5, 8, 16])
-def test_topological_sorting(n_leaves: int):
-    df = alifestd_make_edge_split(n_leaves, seed=42)
-    assert alifestd_is_topologically_sorted(df)
 
 
 @pytest.mark.parametrize("n_leaves", [1, 2, 3, 4, 5, 8])

--- a/tests/test_phyloframe/test_legacy/test_alifestd_make_edge_split.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_make_edge_split.py
@@ -4,6 +4,7 @@ import pytest
 from phyloframe.legacy import (
     alifestd_find_leaf_ids,
     alifestd_is_strictly_bifurcating_asexual,
+    alifestd_is_topologically_sorted,
     alifestd_make_edge_split,
     alifestd_validate,
 )
@@ -41,6 +42,12 @@ def test_validates(n_leaves: int, seed: int):
 def test_bifurcating_structure(n_leaves: int):
     df = alifestd_make_edge_split(n_leaves, seed=42)
     assert alifestd_is_strictly_bifurcating_asexual(df)
+
+
+@pytest.mark.parametrize("n_leaves", [2, 3, 4, 5, 8, 16])
+def test_topological_sorting(n_leaves: int):
+    df = alifestd_make_edge_split(n_leaves, seed=42)
+    assert alifestd_is_topologically_sorted(df)
 
 
 @pytest.mark.parametrize("n_leaves", [1, 2, 3, 4, 5, 8])

--- a/tests/test_phyloframe/test_legacy/test_alifestd_make_edge_split_polars.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_make_edge_split_polars.py
@@ -38,6 +38,12 @@ def test_make_edge_split_polars_deterministic(n_leaves: int, seed: int):
     assert a.equals(b)
 
 
+@pytest.mark.parametrize("n_leaves", [5, 8, 16])
+def test_make_edge_split_polars_no_seed(n_leaves: int):
+    result = alifestd_make_edge_split_polars(n_leaves)
+    assert len(result) == 2 * n_leaves - 1
+
+
 def test_make_edge_split_polars_negative():
     with pytest.raises(ValueError):
         alifestd_make_edge_split_polars(-1, seed=0)

--- a/tests/test_phyloframe/test_legacy/test_alifestd_make_edge_split_polars.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_make_edge_split_polars.py
@@ -1,0 +1,43 @@
+import pytest
+
+from phyloframe.legacy._alifestd_make_edge_split_polars import (
+    alifestd_make_edge_split_polars,
+)
+
+
+def test_make_edge_split_polars_0_leaves():
+    result = alifestd_make_edge_split_polars(0, seed=0)
+    assert result.is_empty()
+    assert "id" in result.columns
+    assert "ancestor_id" in result.columns
+
+
+def test_make_edge_split_polars_1_leaf():
+    result = alifestd_make_edge_split_polars(1, seed=0)
+    assert len(result) == 1
+    assert result["id"].to_list() == [0]
+    assert result["ancestor_id"].to_list() == [0]
+
+
+def test_make_edge_split_polars_2_leaves():
+    result = alifestd_make_edge_split_polars(2, seed=0)
+    assert len(result) == 3
+
+
+@pytest.mark.parametrize("n_leaves", [3, 4, 5, 8, 16])
+def test_make_edge_split_polars_node_count(n_leaves: int):
+    result = alifestd_make_edge_split_polars(n_leaves, seed=42)
+    assert len(result) == 2 * n_leaves - 1
+
+
+@pytest.mark.parametrize("n_leaves", [2, 3, 4, 5, 8, 16])
+@pytest.mark.parametrize("seed", [0, 1, 42])
+def test_make_edge_split_polars_deterministic(n_leaves: int, seed: int):
+    a = alifestd_make_edge_split_polars(n_leaves, seed=seed)
+    b = alifestd_make_edge_split_polars(n_leaves, seed=seed)
+    assert a.equals(b)
+
+
+def test_make_edge_split_polars_negative():
+    with pytest.raises(ValueError):
+        alifestd_make_edge_split_polars(-1, seed=0)

--- a/tests/test_phyloframe/test_legacy/test_alifestd_make_leaf_split.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_make_leaf_split.py
@@ -1,0 +1,99 @@
+import pandas as pd
+import pytest
+
+from phyloframe.legacy import (
+    alifestd_find_leaf_ids,
+    alifestd_make_leaf_split,
+    alifestd_validate,
+)
+
+
+@pytest.mark.parametrize("n_leaves", [2, 3, 4, 5, 8, 16])
+def test_node_count(n_leaves: int):
+    """Total node count should be 2*n_leaves - 1."""
+    df = alifestd_make_leaf_split(n_leaves, seed=42)
+    assert len(df) == 2 * n_leaves - 1
+
+
+@pytest.mark.parametrize("n_leaves", [2, 3, 4, 5, 8, 16])
+def test_leaf_count(n_leaves: int):
+    df = alifestd_make_leaf_split(n_leaves, seed=42)
+    leaf_ids = [*alifestd_find_leaf_ids(df)]
+    assert len(leaf_ids) == n_leaves
+
+
+@pytest.mark.parametrize("n_leaves", [2, 3, 4, 5, 8, 16])
+def test_contiguous_ids(n_leaves: int):
+    df = alifestd_make_leaf_split(n_leaves, seed=42)
+    assert list(df["id"]) == list(range(len(df)))
+
+
+@pytest.mark.parametrize("n_leaves", [1, 2, 3, 4, 5, 8, 16])
+@pytest.mark.parametrize("seed", [0, 1, 42, 12345])
+def test_validates(n_leaves: int, seed: int):
+    df = alifestd_make_leaf_split(n_leaves, seed=seed)
+    assert alifestd_validate(df)
+
+
+@pytest.mark.parametrize("n_leaves", [2, 3, 4, 5, 8, 16])
+def test_bifurcating_structure(n_leaves: int):
+    """Every internal node should have exactly 2 children."""
+    df = alifestd_make_leaf_split(n_leaves, seed=42)
+    leaf_ids = set(alifestd_find_leaf_ids(df))
+    for _, row in df.iterrows():
+        if row["id"] not in leaf_ids:
+            children = df[df["ancestor_list"] == f"[{row['id']}]"]
+            assert len(children) == 2
+
+
+@pytest.mark.parametrize("n_leaves", [2, 3, 4, 5, 8, 16])
+def test_topological_sorting(n_leaves: int):
+    """Parents should appear before children (topologically sorted)."""
+    df = alifestd_make_leaf_split(n_leaves, seed=42)
+    seen = set()
+    for _, row in df.iterrows():
+        if row["ancestor_list"] != "[None]":
+            parent_id = int(row["ancestor_list"].strip("[]"))
+            assert parent_id in seen
+        seen.add(row["id"])
+
+
+@pytest.mark.parametrize("n_leaves", [1, 2, 3, 4, 5, 8])
+def test_returns_dataframe(n_leaves: int):
+    result = alifestd_make_leaf_split(n_leaves, seed=7)
+    assert isinstance(result, pd.DataFrame)
+    assert "id" in result.columns
+    assert "ancestor_list" in result.columns
+
+
+@pytest.mark.parametrize("n_leaves", [2, 3, 4, 5, 8, 16])
+@pytest.mark.parametrize("seed", [0, 1, 42, 12345])
+def test_deterministic(n_leaves: int, seed: int):
+    a = alifestd_make_leaf_split(n_leaves, seed=seed)
+    b = alifestd_make_leaf_split(n_leaves, seed=seed)
+    assert a.equals(b)
+
+
+@pytest.mark.parametrize("n_leaves", [5, 8, 16])
+def test_different_seeds_differ(n_leaves: int):
+    """Different seeds should usually produce different trees."""
+    a = alifestd_make_leaf_split(n_leaves, seed=1)
+    b = alifestd_make_leaf_split(n_leaves, seed=2)
+    assert not a.equals(b)
+
+
+def test_zero_leaves():
+    df = alifestd_make_leaf_split(0, seed=0)
+    assert len(df) == 0
+    assert isinstance(df, pd.DataFrame)
+
+
+def test_single_leaf():
+    df = alifestd_make_leaf_split(1, seed=0)
+    assert len(df) == 1
+    assert df.iloc[0]["ancestor_list"] == "[None]"
+
+
+def test_negative_leaves():
+    with pytest.raises(ValueError):
+        alifestd_make_leaf_split(-1, seed=0)

--- a/tests/test_phyloframe/test_legacy/test_alifestd_make_leaf_split.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_make_leaf_split.py
@@ -82,6 +82,31 @@ def test_different_seeds_differ(n_leaves: int):
     assert not a.equals(b)
 
 
+@pytest.mark.parametrize("n_leaves", [5, 8, 16])
+def test_no_seed(n_leaves: int):
+    """Omitting seed should still produce a valid tree."""
+    df = alifestd_make_leaf_split(n_leaves)
+    assert len(df) == 2 * n_leaves - 1
+
+
+def test_seed_does_not_leak_rng_state():
+    """Using a seed should not perturb outer RNG state."""
+    import random
+
+    import numpy as np
+
+    random.seed(0)
+    np.random.seed(0)
+    expected_py = random.random()
+    expected_np = np.random.random()
+
+    random.seed(0)
+    np.random.seed(0)
+    alifestd_make_leaf_split(16, seed=42)
+    assert random.random() == expected_py
+    assert np.random.random() == expected_np
+
+
 def test_zero_leaves():
     df = alifestd_make_leaf_split(0, seed=0)
     assert len(df) == 0

--- a/tests/test_phyloframe/test_legacy/test_alifestd_make_leaf_split.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_make_leaf_split.py
@@ -3,6 +3,8 @@ import pytest
 
 from phyloframe.legacy import (
     alifestd_find_leaf_ids,
+    alifestd_is_strictly_bifurcating_asexual,
+    alifestd_is_topologically_sorted,
     alifestd_make_leaf_split,
     alifestd_validate,
 )
@@ -37,25 +39,14 @@ def test_validates(n_leaves: int, seed: int):
 
 @pytest.mark.parametrize("n_leaves", [2, 3, 4, 5, 8, 16])
 def test_bifurcating_structure(n_leaves: int):
-    """Every internal node should have exactly 2 children."""
     df = alifestd_make_leaf_split(n_leaves, seed=42)
-    leaf_ids = set(alifestd_find_leaf_ids(df))
-    for _, row in df.iterrows():
-        if row["id"] not in leaf_ids:
-            children = df[df["ancestor_list"] == f"[{row['id']}]"]
-            assert len(children) == 2
+    assert alifestd_is_strictly_bifurcating_asexual(df)
 
 
 @pytest.mark.parametrize("n_leaves", [2, 3, 4, 5, 8, 16])
 def test_topological_sorting(n_leaves: int):
-    """Parents should appear before children (topologically sorted)."""
     df = alifestd_make_leaf_split(n_leaves, seed=42)
-    seen = set()
-    for _, row in df.iterrows():
-        if row["ancestor_list"] != "[None]":
-            parent_id = int(row["ancestor_list"].strip("[]"))
-            assert parent_id in seen
-        seen.add(row["id"])
+    assert alifestd_is_topologically_sorted(df)
 
 
 @pytest.mark.parametrize("n_leaves", [1, 2, 3, 4, 5, 8])

--- a/tests/test_phyloframe/test_legacy/test_alifestd_make_leaf_split_polars.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_make_leaf_split_polars.py
@@ -38,6 +38,12 @@ def test_make_leaf_split_polars_deterministic(n_leaves: int, seed: int):
     assert a.equals(b)
 
 
+@pytest.mark.parametrize("n_leaves", [5, 8, 16])
+def test_make_leaf_split_polars_no_seed(n_leaves: int):
+    result = alifestd_make_leaf_split_polars(n_leaves)
+    assert len(result) == 2 * n_leaves - 1
+
+
 def test_make_leaf_split_polars_negative():
     with pytest.raises(ValueError):
         alifestd_make_leaf_split_polars(-1, seed=0)

--- a/tests/test_phyloframe/test_legacy/test_alifestd_make_leaf_split_polars.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_make_leaf_split_polars.py
@@ -1,0 +1,43 @@
+import pytest
+
+from phyloframe.legacy._alifestd_make_leaf_split_polars import (
+    alifestd_make_leaf_split_polars,
+)
+
+
+def test_make_leaf_split_polars_0_leaves():
+    result = alifestd_make_leaf_split_polars(0, seed=0)
+    assert result.is_empty()
+    assert "id" in result.columns
+    assert "ancestor_id" in result.columns
+
+
+def test_make_leaf_split_polars_1_leaf():
+    result = alifestd_make_leaf_split_polars(1, seed=0)
+    assert len(result) == 1
+    assert result["id"].to_list() == [0]
+    assert result["ancestor_id"].to_list() == [0]
+
+
+def test_make_leaf_split_polars_2_leaves():
+    result = alifestd_make_leaf_split_polars(2, seed=0)
+    assert len(result) == 3
+
+
+@pytest.mark.parametrize("n_leaves", [3, 4, 5, 8, 16])
+def test_make_leaf_split_polars_node_count(n_leaves: int):
+    result = alifestd_make_leaf_split_polars(n_leaves, seed=42)
+    assert len(result) == 2 * n_leaves - 1
+
+
+@pytest.mark.parametrize("n_leaves", [2, 3, 4, 5, 8, 16])
+@pytest.mark.parametrize("seed", [0, 1, 42])
+def test_make_leaf_split_polars_deterministic(n_leaves: int, seed: int):
+    a = alifestd_make_leaf_split_polars(n_leaves, seed=seed)
+    b = alifestd_make_leaf_split_polars(n_leaves, seed=seed)
+    assert a.equals(b)
+
+
+def test_make_leaf_split_polars_negative():
+    with pytest.raises(ValueError):
+        alifestd_make_leaf_split_polars(-1, seed=0)


### PR DESCRIPTION
## Summary
This PR adds two new random bifurcating tree generation functions to the phyloframe library: `alifestd_make_leaf_split` and `alifestd_make_edge_split`, along with their Polars equivalents. These functions generate trees according to different stochastic processes commonly used in phylogenetics and evolutionary biology.

## Key Changes

- **Leaf-split (Yule) tree generation**: Added `alifestd_make_leaf_split()` which generates random bifurcating trees by repeatedly selecting a leaf and splitting it into two new leaves. This produces samples from the Yule (pure-birth) distribution.

- **Edge-split (PDA) tree generation**: Added `alifestd_make_edge_split()` which generates random bifurcating trees by repeatedly selecting an edge and inserting a new internal node with a new leaf sibling. This produces samples from the Proportional-to-Distinguishable-Arrangements (PDA) distribution.

- **Polars variants**: Added `alifestd_make_leaf_split_polars()` and `alifestd_make_edge_split_polars()` for users preferring Polars DataFrames over Pandas.

- **Comprehensive test coverage**: Added extensive test suites for both functions covering:
  - Correct node counts (2*n_leaves - 1)
  - Correct leaf counts
  - Contiguous ID generation
  - Bifurcating structure validation
  - Topological sorting
  - Deterministic behavior with seeds
  - RNG state isolation
  - Edge cases (0 leaves, 1 leaf, negative leaves)

## Implementation Details

- Both functions use JIT-compiled fast paths via Numba for performance
- Seed handling uses a context manager to prevent RNG state leakage
- Functions return empty DataFrames for n_leaves=0 and single-node DataFrames for n_leaves=1
- Negative leaf counts raise ValueError
- Both Pandas and Polars variants share the same core fast-path implementation
- Pandas variants use `ancestor_list` column format (e.g., "[None]", "[5]")
- Polars variants use `ancestor_id` column format (integer IDs)

https://claude.ai/code/session_016rqiCdzZ1sTBDMbPpJ4yd7