### PR TITLE
Add child_order kwarg to contiguous postorder traversal

### DIFF
--- a/phyloframe/legacy/_alifestd_iplotx_provider.py
+++ b/phyloframe/legacy/_alifestd_iplotx_provider.py
@@ -46,6 +46,9 @@ from ._alifestd_try_add_ancestor_id_col_polars import (
 from ._alifestd_unfurl_traversal_levelorder_asexual import (
     _alifestd_unfurl_traversal_levelorder_asexual_fast_path,
 )
+from ._alifestd_unfurl_traversal_postorder_contiguous_asexual import (
+    _alifestd_unfurl_traversal_postorder_contiguous_asexual_asc_jit,
+)
 from ._alifestd_unfurl_traversal_preorder_asexual import (
     _alifestd_unfurl_traversal_preorder_asexual_jit,
 )
@@ -183,22 +186,18 @@ class AlifestdIplotxShimNumpy(TreeDataProvider):
 
     def postorder(self) -> typing.Iterable[_AlifestdNode]:
         # Walk DFS postorder with children visited smallest-id first so the
-        # leaf order matches preorder; the existing JIT helpers visit
+        # leaf order matches preorder; the default JIT helper visits
         # siblings in the opposite direction, which produces mirrored leaf
         # y-coordinates in iplotx rooted layouts.
-        stack = [(int(self._root._id), False)]
-        result = []
-        while stack:
-            node, expanded = stack.pop()
-            if expanded:
-                result.append(node)
-                continue
-            stack.append((node, True))
-            c_start = self._csr_offsets[node]
-            c_end = self._csr_offsets[node + 1]
-            for ci in range(c_end - 1, c_start - 1, -1):
-                stack.append((int(self._csr_children[ci]), False))
-        yield from self._nodes[result]
+        order = (
+            _alifestd_unfurl_traversal_postorder_contiguous_asexual_asc_jit(
+                self._ancestor_ids,
+                self._csr_offsets[:-1],  # without sentinel
+                self._csr_children,
+                self._num_children,
+            )
+        )
+        yield from self._nodes[order]
 
     def levelorder(self) -> typing.Iterable[_AlifestdNode]:
         order = _alifestd_unfurl_traversal_levelorder_asexual_fast_path(

--- a/phyloframe/legacy/_alifestd_unfurl_traversal_postorder_contiguous_asexual.py
+++ b/phyloframe/legacy/_alifestd_unfurl_traversal_postorder_contiguous_asexual.py
@@ -1,3 +1,5 @@
+import typing
+
 import numpy as np
 import pandas as pd
 
@@ -25,7 +27,8 @@ def _alifestd_unfurl_traversal_postorder_contiguous_asexual_sibling_jit(
     """Return DFS postorder traversal using first-child/next-sibling pointers.
 
     Avoids CSR construction by navigating the tree via left-child
-    right-sibling representation.
+    right-sibling representation.  Siblings are visited in descending id
+    order (highest-id child processed first).
 
     Parameters
     ----------
@@ -87,6 +90,80 @@ def _alifestd_unfurl_traversal_postorder_contiguous_asexual_sibling_jit(
 
 
 @jit(nopython=True)
+def _alifestd_unfurl_traversal_postorder_contiguous_asexual_asc_sibling_jit(
+    ancestor_ids: np.ndarray,
+    first_child_ids: np.ndarray,
+    next_sibling_ids: np.ndarray,
+) -> np.ndarray:
+    """Return DFS postorder traversal using first-child/next-sibling pointers.
+
+    Avoids CSR construction by navigating the tree via left-child
+    right-sibling representation.  Siblings are visited in ascending id
+    order (smallest-id child processed first).
+
+    Parameters
+    ----------
+    ancestor_ids : np.ndarray
+        Array of ancestor IDs, assumed contiguous (ids == row indices)
+        and topologically sorted.
+    first_child_ids : np.ndarray
+        Array where first_child_ids[i] is the smallest-id child of i,
+        or i itself if i is a leaf.
+    next_sibling_ids : np.ndarray
+        Array where next_sibling_ids[i] is the next-highest id sharing
+        the same parent, or i itself if no such sibling.
+
+    Returns
+    -------
+    np.ndarray
+        Index array giving DFS postorder traversal order.
+    """
+    n = len(ancestor_ids)
+    dtype = ancestor_ids.dtype
+    if n == 0:
+        return np.empty(0, dtype=dtype)
+
+    result = np.empty(n, dtype=dtype)
+    result_pos = 0
+
+    stack = np.empty(n, dtype=dtype)
+    stack_top = 0
+    expanded = np.zeros(n, dtype=np.bool_)
+
+    for root in range(n):
+        if ancestor_ids[root] != root:
+            continue
+
+        stack[0] = root
+        stack_top = 1
+
+        while stack_top > 0:
+            node = stack[stack_top - 1]
+            first_child = first_child_ids[node]
+
+            if not expanded[node] and first_child != node:
+                expanded[node] = True
+                # Walk siblings into the stack, then reverse so the
+                # smallest-id child ends up on top.
+                base = stack_top
+                sib = first_child
+                while True:
+                    stack[stack_top] = sib
+                    stack_top += 1
+                    nxt = next_sibling_ids[sib]
+                    if nxt == sib:
+                        break
+                    sib = nxt
+                stack[base:stack_top] = stack[base:stack_top][::-1]
+            else:
+                stack_top -= 1
+                result[result_pos] = node
+                result_pos += 1
+
+    return result
+
+
+@jit(nopython=True)
 def _alifestd_unfurl_traversal_postorder_contiguous_asexual_jit(
     ancestor_ids: np.ndarray,
     csr_offsets: np.ndarray,
@@ -96,7 +173,8 @@ def _alifestd_unfurl_traversal_postorder_contiguous_asexual_jit(
     """Return DFS postorder traversal indices for contiguous, sorted phylogeny.
 
     Uses iterative depth-first search so that each subtree's nodes are
-    contiguous in the result.
+    contiguous in the result.  Siblings are visited in descending id order
+    (highest-id child processed first).
 
     Parameters
     ----------
@@ -154,9 +232,78 @@ def _alifestd_unfurl_traversal_postorder_contiguous_asexual_jit(
     return result
 
 
+@jit(nopython=True)
+def _alifestd_unfurl_traversal_postorder_contiguous_asexual_asc_jit(
+    ancestor_ids: np.ndarray,
+    csr_offsets: np.ndarray,
+    csr_children: np.ndarray,
+    num_children: np.ndarray,
+) -> np.ndarray:
+    """Return DFS postorder traversal indices for contiguous, sorted phylogeny.
+
+    Uses iterative depth-first search so that each subtree's nodes are
+    contiguous in the result.  Siblings are visited in ascending id order
+    (smallest-id child processed first).
+
+    Parameters
+    ----------
+    ancestor_ids : np.ndarray
+        Array of ancestor IDs, assumed contiguous (ids == row indices)
+        and topologically sorted.
+    csr_offsets : np.ndarray
+        CSR offset array of length n.
+    csr_children : np.ndarray
+        Flat array of child ids, grouped by parent.
+    num_children : np.ndarray
+        Array of child counts per node.
+
+    Returns
+    -------
+    np.ndarray
+        Index array giving DFS postorder traversal order.
+    """
+    n = len(ancestor_ids)
+    dtype = ancestor_ids.dtype
+    if n == 0:
+        return np.empty(0, dtype=dtype)
+
+    result = np.empty(n, dtype=dtype)
+    result_pos = 0
+
+    stack = np.empty(n, dtype=dtype)
+    stack_top = 0
+    expanded = np.zeros(n, dtype=np.bool_)
+
+    for root in range(n):
+        if ancestor_ids[root] != root:
+            continue
+
+        stack[0] = root
+        stack_top = 1
+
+        while stack_top > 0:
+            node = stack[stack_top - 1]
+            c_start = csr_offsets[node]
+            c_end = c_start + num_children[node]
+
+            if not expanded[node] and c_start < c_end:
+                expanded[node] = True
+                # Push children in reverse so smallest-id is on top
+                for ci in range(c_end - 1, c_start - 1, -1):
+                    stack[stack_top] = csr_children[ci]
+                    stack_top += 1
+            else:
+                stack_top -= 1
+                result[result_pos] = node
+                result_pos += 1
+
+    return result
+
+
 def alifestd_unfurl_traversal_postorder_contiguous_asexual(
     phylogeny_df: pd.DataFrame,
     mutate: bool = False,
+    child_order: typing.Optional[typing.Literal["asc", "desc"]] = None,
 ) -> np.ndarray:
     """List node indices in DFS postorder traversal order, with subtree
     contiguity.
@@ -167,7 +314,25 @@ def alifestd_unfurl_traversal_postorder_contiguous_asexual(
     Input dataframe is not mutated by this operation unless `mutate` set True.
     If mutate set True, operation does not occur in place; still use return
     value to get transformed phylogeny dataframe.
+
+    Parameters
+    ----------
+    phylogeny_df : pd.DataFrame
+        Asexual phylogeny in alife standard format with contiguous ids
+        and topologically sorted rows.
+    mutate : bool, default False
+        If True, allow modification of the input dataframe.
+    child_order : {"asc", "desc", None}, default None
+        Order in which siblings are visited when descending the tree.
+        ``"asc"`` visits smallest-id child first, ``"desc"`` visits
+        largest-id child first, and ``None`` uses an arbitrary
+        (implementation-defined) order.
     """
+    if child_order not in (None, "asc", "desc"):
+        raise ValueError(
+            f"child_order must be 'asc', 'desc', or None; got {child_order!r}",
+        )
+
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 
@@ -188,10 +353,18 @@ def alifestd_unfurl_traversal_postorder_contiguous_asexual(
         "first_child_id" in phylogeny_df.columns
         and "next_sibling_id" in phylogeny_df.columns
     ):
+        first_child_ids = phylogeny_df["first_child_id"].to_numpy()
+        next_sibling_ids = phylogeny_df["next_sibling_id"].to_numpy()
+        if child_order == "asc":
+            return _alifestd_unfurl_traversal_postorder_contiguous_asexual_asc_sibling_jit(
+                ancestor_ids,
+                first_child_ids,
+                next_sibling_ids,
+            )
         return _alifestd_unfurl_traversal_postorder_contiguous_asexual_sibling_jit(
             ancestor_ids,
-            phylogeny_df["first_child_id"].to_numpy(),
-            phylogeny_df["next_sibling_id"].to_numpy(),
+            first_child_ids,
+            next_sibling_ids,
         )
     if "num_children" not in phylogeny_df.columns:
         num_children = _alifestd_mark_num_children_asexual_fast_path(
@@ -211,6 +384,13 @@ def alifestd_unfurl_traversal_postorder_contiguous_asexual(
         csr_children = _alifestd_mark_csr_children_asexual_fast_path(
             ancestor_ids,
             csr_offsets,
+        )
+    if child_order == "asc":
+        return _alifestd_unfurl_traversal_postorder_contiguous_asexual_asc_jit(
+            ancestor_ids,
+            csr_offsets,
+            csr_children,
+            num_children,
         )
     return _alifestd_unfurl_traversal_postorder_contiguous_asexual_jit(
         ancestor_ids,

--- a/tests/test_phyloframe/test_legacy/test_alifestd_unfurl_traversal_postorder_contiguous_asexual.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_unfurl_traversal_postorder_contiguous_asexual.py
@@ -350,3 +350,194 @@ def test_sibling_fast_path_matches_baseline(phylogeny_csv: str):
     )
 
     assert result_base.tolist() == result_sib.tolist()
+
+
+@_prep_params
+@pytest.mark.parametrize("child_order", [None, "asc", "desc"])
+def test_child_order_chain(apply: typing.Callable, child_order):
+    """Linear chains have no sibling ordering choice."""
+    df = _make_contiguous_df(np.array([0, 0, 1]))
+    result = alifestd_unfurl_traversal_postorder_contiguous_asexual(
+        apply(df),
+        child_order=child_order,
+    )
+    assert result.tolist() == [2, 1, 0]
+
+
+@_prep_params
+def test_child_order_asc_simple_branching(apply: typing.Callable):
+    """Tree: 0 -> {1, 2}, 1 -> {3}.
+
+    With ``child_order='asc'`` the smallest-id child is visited first,
+    so the subtree of 1 (which contains 3) is processed before 2.
+    Result: [3, 1, 2, 0]
+    """
+    df = _make_contiguous_df(np.array([0, 0, 0, 1]))
+    result = alifestd_unfurl_traversal_postorder_contiguous_asexual(
+        apply(df),
+        child_order="asc",
+    )
+    assert result.tolist() == [3, 1, 2, 0]
+
+
+@_prep_params
+def test_child_order_desc_simple_branching(apply: typing.Callable):
+    """Tree: 0 -> {1, 2}, 1 -> {3}.
+
+    With ``child_order='desc'`` the largest-id child is visited first,
+    matching the existing default behavior.
+    """
+    df = _make_contiguous_df(np.array([0, 0, 0, 1]))
+    result = alifestd_unfurl_traversal_postorder_contiguous_asexual(
+        apply(df),
+        child_order="desc",
+    )
+    assert result.tolist() == [2, 3, 1, 0]
+
+
+@_prep_params
+def test_child_order_asc_star(apply: typing.Callable):
+    """Star graph: root 0 with children 1, 2, 3, 4."""
+    df = _make_contiguous_df(np.array([0, 0, 0, 0, 0]))
+    result = alifestd_unfurl_traversal_postorder_contiguous_asexual(
+        apply(df),
+        child_order="asc",
+    )
+    assert result.tolist() == [1, 2, 3, 4, 0]
+
+
+@_prep_params
+def test_child_order_desc_star(apply: typing.Callable):
+    """Star graph: root 0 with children 1, 2, 3, 4."""
+    df = _make_contiguous_df(np.array([0, 0, 0, 0, 0]))
+    result = alifestd_unfurl_traversal_postorder_contiguous_asexual(
+        apply(df),
+        child_order="desc",
+    )
+    assert result.tolist() == [4, 3, 2, 1, 0]
+
+
+@_prep_params
+def test_child_order_asc_subtree_contiguity(apply: typing.Callable):
+    """Verify ascending traversal: smallest-id sibling first.
+
+    Tree: 0 -> {1, 2}, 1 -> {3, 4}, 2 -> {5}.
+    Result: [3, 4, 1, 5, 2, 0]
+    """
+    df = _make_contiguous_df(np.array([0, 0, 0, 1, 1, 2]))
+    result = alifestd_unfurl_traversal_postorder_contiguous_asexual(
+        apply(df),
+        child_order="asc",
+    )
+    assert result.tolist() == [3, 4, 1, 5, 2, 0]
+
+
+@_prep_params
+def test_child_order_none_matches_default(apply: typing.Callable):
+    """``child_order=None`` should match the default (no kwarg)."""
+    df = _make_contiguous_df(np.array([0, 0, 0, 1, 1, 2]))
+    default = alifestd_unfurl_traversal_postorder_contiguous_asexual(apply(df))
+    none_result = alifestd_unfurl_traversal_postorder_contiguous_asexual(
+        apply(df),
+        child_order=None,
+    )
+    assert default.tolist() == none_result.tolist()
+
+
+def test_child_order_invalid():
+    """Invalid ``child_order`` values must raise ``ValueError``."""
+    df = _make_contiguous_df(np.array([0, 0, 1]))
+    with pytest.raises(ValueError):
+        alifestd_unfurl_traversal_postorder_contiguous_asexual(
+            df,
+            child_order="bogus",
+        )
+
+
+@pytest.mark.parametrize(
+    "phylogeny_csv",
+    [
+        "example-standard-toy-asexual-phylogeny.csv",
+        "nk_ecoeaselection.csv",
+        "nk_lexicaseselection.csv",
+        "nk_tournamentselection.csv",
+    ],
+)
+@pytest.mark.parametrize("child_order", ["asc", "desc"])
+@_prep_params
+def test_child_order_valid_postorder(
+    phylogeny_csv: str,
+    child_order: str,
+    apply: typing.Callable,
+):
+    """Both ``child_order`` modes must produce a valid postorder."""
+    from phyloframe.legacy import alifestd_try_add_ancestor_id_col
+
+    phylogeny_df = pd.read_csv(f"{assets_path}/{phylogeny_csv}")
+    phylogeny_df = phylogeny_df.sort_values("id").reset_index(drop=True)
+    phylogeny_df = alifestd_try_add_ancestor_id_col(phylogeny_df.copy())
+    ids = phylogeny_df["id"].to_numpy()
+    id_map = {int(old): new for new, old in enumerate(ids)}
+    ancestor_ids = np.array(
+        [id_map[int(a)] for a in phylogeny_df["ancestor_id"].to_numpy()],
+        dtype=np.int64,
+    )
+    df = _make_contiguous_df(ancestor_ids)
+    result = alifestd_unfurl_traversal_postorder_contiguous_asexual(
+        apply(df),
+        child_order=child_order,
+    )
+
+    n = len(ancestor_ids)
+    assert len(result) == n
+    assert set(result) == set(range(n))
+
+    pos = {node: i for i, node in enumerate(result)}
+    for child in range(n):
+        parent = ancestor_ids[child]
+        if child != parent:
+            assert pos[child] < pos[parent]
+
+
+@pytest.mark.parametrize(
+    "phylogeny_csv",
+    [
+        "example-standard-toy-asexual-phylogeny.csv",
+        "nk_ecoeaselection.csv",
+        "nk_lexicaseselection.csv",
+        "nk_tournamentselection.csv",
+    ],
+)
+def test_child_order_asc_csr_matches_sibling(phylogeny_csv: str):
+    """CSR and sibling fast paths must agree for ``child_order='asc'``."""
+    from phyloframe.legacy import (
+        alifestd_mark_first_child_id_asexual,
+        alifestd_mark_next_sibling_id_asexual,
+        alifestd_try_add_ancestor_id_col,
+    )
+
+    phylogeny_df = pd.read_csv(f"{assets_path}/{phylogeny_csv}")
+    phylogeny_df = phylogeny_df.sort_values("id").reset_index(drop=True)
+    phylogeny_df = alifestd_try_add_ancestor_id_col(phylogeny_df.copy())
+    ids = phylogeny_df["id"].to_numpy()
+    id_map = {int(old): new for new, old in enumerate(ids)}
+    ancestor_ids = np.array(
+        [id_map[int(a)] for a in phylogeny_df["ancestor_id"].to_numpy()],
+        dtype=np.int64,
+    )
+    df_base = _make_contiguous_df(ancestor_ids)
+
+    result_csr = alifestd_unfurl_traversal_postorder_contiguous_asexual(
+        df_base,
+        child_order="asc",
+    )
+
+    df_sib = df_base.copy()
+    df_sib = alifestd_mark_first_child_id_asexual(df_sib, mutate=True)
+    df_sib = alifestd_mark_next_sibling_id_asexual(df_sib, mutate=True)
+    result_sib = alifestd_unfurl_traversal_postorder_contiguous_asexual(
+        df_sib,
+        child_order="asc",
+    )
+
+    assert result_csr.tolist() == result_sib.tolist()


### PR DESCRIPTION
Introduces an alternate ``_asc`` fast path (CSR + sibling variants) that
visits siblings in ascending id order, alongside the existing default
that visits in descending id order. The public
``alifestd_unfurl_traversal_postorder_contiguous_asexual`` now accepts
``child_order`` taking ``"asc"``, ``"desc"``, or ``None`` (arbitrary).

The iplotx ``postorder`` shim is rewritten to delegate to the new
ascending JIT instead of an inline Python loop, keeping leaf order in
sync with preorder for rooted layouts.