### PR TITLE
Move benchmark job to separate workflow file

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,0 +1,57 @@
+name: benchmark
+
+on:
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    name: "benchmark ${{ matrix.n_leaves }} leaves"
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        n_leaves:
+          - 100
+          - 300
+          - 1000
+          - 3000
+          - 10000
+          - 30000
+          - 100000
+          - 300000
+          - 1000000
+          - 3000000
+          - 10000000
+          - 30000000
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.12"
+      - name: Install phyloframe
+        run: python3 -m pip install ".[jit]"
+      - name: Install benchmark dependencies
+        run: |
+          sudo apt-get install -y swig
+          python3 -m pip install \
+            biopython==1.86 \
+            dendropy==5.0.8 \
+            treeswift==1.1.45 \
+            ete3==3.1.3 \
+            psutil \
+            scikit-bio==0.6.3 \
+            SuchTree==1.3
+          python3 -m pip download CompactTree==1.0.0 --no-binary :all: -d /tmp/ct
+          cd /tmp && tar xzf ct/compacttree-1.0.0.tar.gz
+          sed -i '1a %begin %{\n#include <cstdint>\n%}' \
+            /tmp/compacttree-1.0.0/CompactTree/compact_tree.i
+          python3 -m pip install /tmp/compacttree-1.0.0
+      - name: Run benchmark
+        run: python3 joss/benchmark.py --size ${{ matrix.n_leaves }} > joss/benchmark-results.csv
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ matrix.n_leaves }}
+          path: joss/benchmark-results.csv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -306,59 +306,6 @@ jobs:
           # paper.md
           path: joss/paper.pdf
 
-  benchmark:
-    if: github.event_name == 'workflow_dispatch'
-    name: "benchmark ${{ matrix.n_leaves }} leaves"
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        n_leaves:
-          - 100
-          - 300
-          - 1000
-          - 3000
-          - 10000
-          - 30000
-          - 100000
-          - 300000
-          - 1000000
-          - 3000000
-          - 10000000
-          - 30000000
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.12"
-      - name: Install phyloframe
-        run: python3 -m pip install ".[jit]"
-      - name: Install benchmark dependencies
-        run: |
-          sudo apt-get install -y swig
-          python3 -m pip install \
-            biopython==1.86 \
-            dendropy==5.0.8 \
-            treeswift==1.1.45 \
-            ete3==3.1.3 \
-            psutil \
-            scikit-bio==0.6.3 \
-            SuchTree==1.3
-          python3 -m pip download CompactTree==1.0.0 --no-binary :all: -d /tmp/ct
-          cd /tmp && tar xzf ct/compacttree-1.0.0.tar.gz
-          sed -i '1a %begin %{\n#include <cstdint>\n%}' \
-            /tmp/compacttree-1.0.0/CompactTree/compact_tree.i
-          python3 -m pip install /tmp/compacttree-1.0.0
-      - name: Run benchmark
-        run: python3 joss/benchmark.py --size ${{ matrix.n_leaves }} > joss/benchmark-results.csv
-      - name: Upload benchmark results
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-results-${{ matrix.n_leaves }}
-          path: joss/benchmark-results.csv
-
   deploy-test:
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
## Summary
Refactored the GitHub Actions workflow configuration by extracting the benchmark job from the main CI workflow into a dedicated workflow file for better organization and maintainability.

## Changes
- Created new `.github/workflows/benchmark.yaml` containing the benchmark job that was previously in `ci.yaml`
- Removed the benchmark job from `.github/workflows/ci.yaml`
- The benchmark workflow is triggered manually via `workflow_dispatch` event

## Benefits
- Separates concerns by keeping benchmark jobs independent from the main CI pipeline
- Improves CI workflow clarity by removing a large conditional job block
- Makes it easier to manage and modify benchmark-specific configurations independently
- Reduces clutter in the main CI workflow file

https://claude.ai/code/session_01BBm7YtGQ2HexB34nanZzt9