### PR TITLE
Add Polars implementation of leaf isomorphism test

### DIFF
--- a/phyloframe/__main__.py
+++ b/phyloframe/__main__.py
@@ -159,6 +159,7 @@ $ python3 -m phyloframe.legacy._alifestd_sort_children_polars
 $ python3 -m phyloframe.legacy._alifestd_splay_polytomies
 $ python3 -m phyloframe.legacy._alifestd_splay_polytomies_polars
 $ python3 -m phyloframe.legacy._alifestd_test_leaves_isomorphic_asexual
+$ python3 -m phyloframe.legacy._alifestd_test_leaves_isomorphic_polars
 $ python3 -m phyloframe.legacy._alifestd_to_working_format
 $ python3 -m phyloframe.legacy._alifestd_topological_sort
 $ python3 -m phyloframe.legacy._alifestd_topological_sort_polars

--- a/phyloframe/legacy/__init__.pyi
+++ b/phyloframe/legacy/__init__.pyi
@@ -592,6 +592,9 @@ from ._alifestd_sum_origin_time_deltas_polars import (
 from ._alifestd_test_leaves_isomorphic_asexual import (
     alifestd_test_leaves_isomorphic_asexual,
 )
+from ._alifestd_test_leaves_isomorphic_polars import (
+    alifestd_test_leaves_isomorphic_polars,
+)
 from ._alifestd_to_working_format import alifestd_to_working_format
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
@@ -929,6 +932,7 @@ __all__ = [
     "alifestd_sum_origin_time_deltas_asexual",
     "alifestd_sum_origin_time_deltas_polars",
     "alifestd_test_leaves_isomorphic_asexual",
+    "alifestd_test_leaves_isomorphic_polars",
     "alifestd_to_working_format",
     "alifestd_topological_sensitivity_warned",
     "alifestd_topological_sensitivity_warned_polars",

--- a/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
+++ b/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
@@ -46,12 +46,11 @@ def _walk_leaves_isomorphic(
     every leaf in df1 with matching taxon label in df2; ``id_map_set`` is a
     parallel boolean mask indicating which entries of ``id_map`` are valid.
     """
-    n = jit_numpy_int64_t(len(ancestor_ids1))
-    for offset in range(n):
-        id1 = n - 1 - offset
+    # iterate over ids from back to front
+    for id1_r, ancestor_id1 in enumerate(ancestor_ids1[::-1]):
+        id1 = jit_numpy_int64_t(len(ancestor_ids1) - 1 - id1_r)
         if not id_map_set[id1]:
             return False
-        ancestor_id1 = ancestor_ids1[id1]
         id2 = id_map[id1]
         ancestor_id2 = ancestor_ids2[id2]
         if id_map_set[ancestor_id1]:

--- a/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
+++ b/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
@@ -69,34 +69,6 @@ def _walk_leaves_isomorphic(
     return True
 
 
-def _canonicalize(df: pl.LazyFrame) -> pl.LazyFrame:
-    """Validate preconditions and prepare ``df`` for the leaf-isomorphism walk.
-
-    Adds ``ancestor_id`` (if absent and derivable from ``ancestor_list``),
-    drops ``ancestor_list``, collapses unifurcations, recompacts ids so
-    the jit walk can index by id, and ensures ``is_leaf`` is present.
-    """
-    df = alifestd_try_add_ancestor_id_col_polars(df)
-    if "ancestor_id" not in df.collect_schema().names():
-        raise NotImplementedError("ancestor_id column required")
-    if not alifestd_is_topologically_sorted_polars(df):
-        raise NotImplementedError("topological sort not yet supported")
-    if not alifestd_has_contiguous_ids_polars(df):
-        raise NotImplementedError("non-contiguous ids not yet supported")
-    df = (
-        df.select(pl.exclude("ancestor_list"))
-        .pipe(
-            alifestd_collapse_unifurcations_polars,
-            drop_topological_sensitivity=True,
-        )
-        .pipe(alifestd_assign_contiguous_ids_polars)
-        .lazy()
-    )
-    if "is_leaf" not in df.collect_schema().names():
-        df = alifestd_mark_leaves_polars(df)
-    return df
-
-
 def alifestd_test_leaves_isomorphic_polars(
     df1: pl.DataFrame,
     df2: pl.DataFrame,
@@ -116,8 +88,59 @@ def alifestd_test_leaves_isomorphic_polars(
     ):
         return True
 
-    df1 = df1.lazy().pipe(_canonicalize)
-    df2 = df2.lazy().pipe(_canonicalize)
+    df1 = alifestd_try_add_ancestor_id_col_polars(df1.lazy())
+    df2 = alifestd_try_add_ancestor_id_col_polars(df2.lazy())
+    if (
+        "ancestor_id" not in df1.collect_schema().names()
+        or "ancestor_id" not in df2.collect_schema().names()
+    ):
+        raise NotImplementedError("ancestor_id column required")
+
+    if not alifestd_is_topologically_sorted_polars(
+        df1
+    ) or not alifestd_is_topologically_sorted_polars(df2):
+        raise NotImplementedError("topological sort not yet supported")
+
+    if not alifestd_has_contiguous_ids_polars(
+        df1
+    ) or not alifestd_has_contiguous_ids_polars(df2):
+        raise NotImplementedError("non-contiguous ids not yet supported")
+
+    # collapse_unifurcations_polars and assign_contiguous_ids_polars reject
+    # the ancestor_list column; drop it inline (no-op if absent). Casting
+    # ``id``/``ancestor_id`` to Int64 here lets us avoid copy-converting the
+    # numpy arrays before handing them to the jit kernel.
+    df1 = (
+        df1.select(pl.exclude("ancestor_list"))
+        .pipe(
+            alifestd_collapse_unifurcations_polars,
+            drop_topological_sensitivity=True,
+        )
+        .pipe(alifestd_assign_contiguous_ids_polars)
+        .lazy()
+        .with_columns(
+            pl.col("id").cast(pl.Int64),
+            pl.col("ancestor_id").cast(pl.Int64),
+        )
+    )
+    df2 = (
+        df2.select(pl.exclude("ancestor_list"))
+        .pipe(
+            alifestd_collapse_unifurcations_polars,
+            drop_topological_sensitivity=True,
+        )
+        .pipe(alifestd_assign_contiguous_ids_polars)
+        .lazy()
+        .with_columns(
+            pl.col("id").cast(pl.Int64),
+            pl.col("ancestor_id").cast(pl.Int64),
+        )
+    )
+
+    if "is_leaf" not in df1.collect_schema().names():
+        df1 = alifestd_mark_leaves_polars(df1)
+    if "is_leaf" not in df2.collect_schema().names():
+        df2 = alifestd_mark_leaves_polars(df2)
 
     n_leaves1 = alifestd_count_leaf_nodes_polars(df1)
     n_leaves2 = alifestd_count_leaf_nodes_polars(df2)
@@ -129,8 +152,9 @@ def alifestd_test_leaves_isomorphic_polars(
     )
     # sorting both leaf sets by taxon label aligns matching leaves
     # element-wise, side-stepping a join (and the column-aliasing it would
-    # require to disambiguate "id" between the two frames).
-    leaf_cols = ["id"] if taxon_label == "id" else ["id", taxon_label]
+    # require to disambiguate "id" between the two frames). Use a set so
+    # ``taxon_label == "id"`` doesn't produce a duplicate-projection error.
+    leaf_cols = list({"id", taxon_label})
     leaves1_sorted = (
         df1.filter(pl.col("is_leaf"))
         .sort(taxon_label)
@@ -159,10 +183,10 @@ def alifestd_test_leaves_isomorphic_polars(
 
     return bool(
         _walk_leaves_isomorphic(
-            ancestor_ids1.astype(np.int64, copy=True),
-            ancestor_ids2.astype(np.int64, copy=True),
-            leaves1_sorted["id"].to_numpy().astype(np.int64),
-            leaves2_sorted["id"].to_numpy().astype(np.int64),
+            ancestor_ids1,
+            ancestor_ids2,
+            leaves1_sorted["id"].to_numpy(),
+            leaves2_sorted["id"].to_numpy(),
         ),
     )
 

--- a/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
+++ b/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
@@ -164,7 +164,7 @@ def alifestd_test_leaves_isomorphic_polars(
     )
 
     if leaves1_sorted[taxon_label].n_unique() != n_leaves1:
-        raise ValueError("taxon labels in df1 must be unique among leaves")
+        raise ValueError("taxon labels must be unique among leaves")
     if not leaves1_sorted[taxon_label].equals(leaves2_sorted[taxon_label]):
         return False
 

--- a/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
+++ b/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
@@ -57,8 +57,8 @@ def _walk_leaves_isomorphic(
     # below need not re-verify ``id_map_set[id1]`` per iteration.
 
     # iterate over ids from back to front
-    for id1_r, ancestor_id1 in enumerate(ancestor_ids1[::-1]):
-        id1 = jit_numpy_int64_t(n - 1 - id1_r)
+    for id1 in range(n - 1, -1, -1):
+        ancestor_id1 = ancestor_ids1[id1]
         id2 = id_map[id1]
         ancestor_id2 = ancestor_ids2[id2]
         if id_map_set[ancestor_id1]:

--- a/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
+++ b/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
@@ -115,7 +115,6 @@ def alifestd_test_leaves_isomorphic_polars(
             drop_topological_sensitivity=True,
         )
         .pipe(alifestd_assign_contiguous_ids_polars)
-        .lazy()
     )
     df2 = (
         df2.select(pl.exclude("ancestor_list"))
@@ -124,7 +123,6 @@ def alifestd_test_leaves_isomorphic_polars(
             drop_topological_sensitivity=True,
         )
         .pipe(alifestd_assign_contiguous_ids_polars)
-        .lazy()
     )
 
     if "is_leaf" not in df1.collect_schema().names():
@@ -151,13 +149,15 @@ def alifestd_test_leaves_isomorphic_polars(
         for c in {"id", taxon_label}
     ]
     leaves1_sorted = (
-        df1.filter(pl.col("is_leaf"))
+        df1.lazy()
+        .filter(pl.col("is_leaf"))
         .sort(taxon_label)
         .select(leaf_cols)
         .collect()
     )
     leaves2_sorted = (
-        df2.filter(pl.col("is_leaf"))
+        df2.lazy()
+        .filter(pl.col("is_leaf"))
         .sort(taxon_label)
         .select(leaf_cols)
         .collect()
@@ -172,13 +172,15 @@ def alifestd_test_leaves_isomorphic_polars(
         "- alifestd_test_leaves_isomorphic_polars: collecting ancestor ids...",
     )
     ancestor_ids1 = (
-        df1.select(pl.col("ancestor_id").cast(pl.Int64))
+        df1.lazy()
+        .select(pl.col("ancestor_id").cast(pl.Int64))
         .collect()
         .to_series()
         .to_numpy()
     )
     ancestor_ids2 = (
-        df2.select(pl.col("ancestor_id").cast(pl.Int64))
+        df2.lazy()
+        .select(pl.col("ancestor_id").cast(pl.Int64))
         .collect()
         .to_series()
         .to_numpy()

--- a/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
+++ b/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
@@ -29,6 +29,9 @@ from ._alifestd_is_topologically_sorted_polars import (
     alifestd_is_topologically_sorted_polars,
 )
 from ._alifestd_mark_leaves_polars import alifestd_mark_leaves_polars
+from ._alifestd_try_add_ancestor_id_col_polars import (
+    alifestd_try_add_ancestor_id_col_polars,
+)
 
 
 @jit(nopython=True)
@@ -66,6 +69,34 @@ def _walk_leaves_isomorphic(
     return True
 
 
+def _canonicalize(df: pl.LazyFrame) -> pl.LazyFrame:
+    """Validate preconditions and prepare ``df`` for the leaf-isomorphism walk.
+
+    Adds ``ancestor_id`` (if absent and derivable from ``ancestor_list``),
+    drops ``ancestor_list``, collapses unifurcations, recompacts ids so
+    the jit walk can index by id, and ensures ``is_leaf`` is present.
+    """
+    df = alifestd_try_add_ancestor_id_col_polars(df)
+    if "ancestor_id" not in df.collect_schema().names():
+        raise NotImplementedError("ancestor_id column required")
+    if not alifestd_is_topologically_sorted_polars(df):
+        raise NotImplementedError("topological sort not yet supported")
+    if not alifestd_has_contiguous_ids_polars(df):
+        raise NotImplementedError("non-contiguous ids not yet supported")
+    df = (
+        df.select(pl.exclude("ancestor_list"))
+        .pipe(
+            alifestd_collapse_unifurcations_polars,
+            drop_topological_sensitivity=True,
+        )
+        .pipe(alifestd_assign_contiguous_ids_polars)
+        .lazy()
+    )
+    if "is_leaf" not in df.collect_schema().names():
+        df = alifestd_mark_leaves_polars(df)
+    return df
+
+
 def alifestd_test_leaves_isomorphic_polars(
     df1: pl.DataFrame,
     df2: pl.DataFrame,
@@ -79,59 +110,14 @@ def alifestd_test_leaves_isomorphic_polars(
     alifestd_test_leaves_isomorphic_asexual :
         Pandas-based implementation.
     """
-    df1 = df1.lazy()
-    df2 = df2.lazy()
-
-    if df1.limit(1).collect().is_empty() and df2.limit(1).collect().is_empty():
+    if (
+        df1.lazy().limit(1).collect().is_empty()
+        and df2.lazy().limit(1).collect().is_empty()
+    ):
         return True
 
-    schema1 = df1.collect_schema().names()
-    schema2 = df2.collect_schema().names()
-    if "ancestor_id" not in schema1 or "ancestor_id" not in schema2:
-        raise NotImplementedError("ancestor_id column required")
-
-    if not alifestd_is_topologically_sorted_polars(
-        df1
-    ) or not alifestd_is_topologically_sorted_polars(df2):
-        raise NotImplementedError("topological sort not yet supported")
-
-    if not alifestd_has_contiguous_ids_polars(
-        df1
-    ) or not alifestd_has_contiguous_ids_polars(df2):
-        raise NotImplementedError("non-contiguous ids not yet supported")
-
-    # collapse_unifurcations_polars and assign_contiguous_ids_polars reject
-    # the ancestor_list column; drop it inline (no-op if absent).
-    df1 = df1.select(pl.exclude("ancestor_list"))
-    df2 = df2.select(pl.exclude("ancestor_list"))
-
-    logging.info(
-        "- alifestd_test_leaves_isomorphic_polars: "
-        "collapsing unifurcations...",
-    )
-    df1 = alifestd_collapse_unifurcations_polars(
-        df1,
-        ignore_topological_sensitivity=True,
-        drop_topological_sensitivity=False,
-    )
-    df2 = alifestd_collapse_unifurcations_polars(
-        df2,
-        ignore_topological_sensitivity=True,
-        drop_topological_sensitivity=False,
-    )
-
-    # collapse_unifurcations leaves gapped ids; recompact so the jit walk
-    # below can index by id.
-    df1 = alifestd_assign_contiguous_ids_polars(df1).lazy()
-    df2 = alifestd_assign_contiguous_ids_polars(df2).lazy()
-
-    logging.info(
-        "- alifestd_test_leaves_isomorphic_polars: marking leaves...",
-    )
-    if "is_leaf" not in df1.collect_schema().names():
-        df1 = alifestd_mark_leaves_polars(df1)
-    if "is_leaf" not in df2.collect_schema().names():
-        df2 = alifestd_mark_leaves_polars(df2)
+    df1 = df1.lazy().pipe(_canonicalize)
+    df2 = df2.lazy().pipe(_canonicalize)
 
     n_leaves1 = alifestd_count_leaf_nodes_polars(df1)
     n_leaves2 = alifestd_count_leaf_nodes_polars(df2)

--- a/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
+++ b/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
@@ -107,9 +107,7 @@ def alifestd_test_leaves_isomorphic_polars(
         raise NotImplementedError("non-contiguous ids not yet supported")
 
     # collapse_unifurcations_polars and assign_contiguous_ids_polars reject
-    # the ancestor_list column; drop it inline (no-op if absent). Casting
-    # ``id``/``ancestor_id`` to Int64 here lets us avoid copy-converting the
-    # numpy arrays before handing them to the jit kernel.
+    # the ancestor_list column; drop it inline (no-op if absent).
     df1 = (
         df1.select(pl.exclude("ancestor_list"))
         .pipe(
@@ -118,10 +116,6 @@ def alifestd_test_leaves_isomorphic_polars(
         )
         .pipe(alifestd_assign_contiguous_ids_polars)
         .lazy()
-        .with_columns(
-            pl.col("id").cast(pl.Int64),
-            pl.col("ancestor_id").cast(pl.Int64),
-        )
     )
     df2 = (
         df2.select(pl.exclude("ancestor_list"))
@@ -131,10 +125,6 @@ def alifestd_test_leaves_isomorphic_polars(
         )
         .pipe(alifestd_assign_contiguous_ids_polars)
         .lazy()
-        .with_columns(
-            pl.col("id").cast(pl.Int64),
-            pl.col("ancestor_id").cast(pl.Int64),
-        )
     )
 
     if "is_leaf" not in df1.collect_schema().names():
@@ -154,7 +144,12 @@ def alifestd_test_leaves_isomorphic_polars(
     # element-wise, side-stepping a join (and the column-aliasing it would
     # require to disambiguate "id" between the two frames). Use a set so
     # ``taxon_label == "id"`` doesn't produce a duplicate-projection error.
-    leaf_cols = list({"id", taxon_label})
+    # cast ``id`` to Int64 lazily in the same chain so the numpy array we
+    # hand to the jit kernel doesn't need a follow-up ``.astype`` copy.
+    leaf_cols = [
+        pl.col(c).cast(pl.Int64) if c == "id" else pl.col(c)
+        for c in {"id", taxon_label}
+    ]
     leaves1_sorted = (
         df1.filter(pl.col("is_leaf"))
         .sort(taxon_label)
@@ -176,8 +171,18 @@ def alifestd_test_leaves_isomorphic_polars(
     logging.info(
         "- alifestd_test_leaves_isomorphic_polars: collecting ancestor ids...",
     )
-    ancestor_ids1 = df1.select("ancestor_id").collect().to_series().to_numpy()
-    ancestor_ids2 = df2.select("ancestor_id").collect().to_series().to_numpy()
+    ancestor_ids1 = (
+        df1.select(pl.col("ancestor_id").cast(pl.Int64))
+        .collect()
+        .to_series()
+        .to_numpy()
+    )
+    ancestor_ids2 = (
+        df2.select(pl.col("ancestor_id").cast(pl.Int64))
+        .collect()
+        .to_series()
+        .to_numpy()
+    )
     if len(ancestor_ids1) != len(ancestor_ids2):
         return False
 

--- a/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
+++ b/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
@@ -88,8 +88,8 @@ def alifestd_test_leaves_isomorphic_polars(
     ):
         return True
 
-    df1 = alifestd_try_add_ancestor_id_col_polars(df1.lazy())
-    df2 = alifestd_try_add_ancestor_id_col_polars(df2.lazy())
+    df1 = alifestd_try_add_ancestor_id_col_polars(df1)
+    df2 = alifestd_try_add_ancestor_id_col_polars(df2)
     if (
         "ancestor_id" not in df1.collect_schema().names()
         or "ancestor_id" not in df2.collect_schema().names()

--- a/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
+++ b/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
@@ -35,22 +35,30 @@ from ._alifestd_try_add_ancestor_id_col_polars import (
 def _walk_leaves_isomorphic(
     ancestor_ids1: np.ndarray,
     ancestor_ids2: np.ndarray,
-    id_map: np.ndarray,
-    id_map_set: np.ndarray,
+    leaf_ids1: np.ndarray,
+    leaf_ids2: np.ndarray,
 ) -> jit_numpy_bool_t:
     """Walk ids backward and propagate the leaf-induced id mapping toward the
     roots, returning False if any node's ancestor mapping is inconsistent.
 
     Both phylogenies are assumed to be topologically sorted with contiguous
-    ids. ``id_map`` should be initialized so that ``id_map[id1] = id2`` for
-    every leaf in df1 with matching taxon label in df2; ``id_map_set`` is a
-    parallel boolean mask indicating which entries of ``id_map`` are valid.
+    ids. ``leaf_ids1[i]`` and ``leaf_ids2[i]`` give the corresponding ids in
+    df1 and df2, respectively, for the ``i``th matched leaf.
     """
+    n = len(ancestor_ids1)
+    id_map = np.zeros(n, dtype=jit_numpy_int64_t)
+    id_map_set = np.zeros(n, dtype=jit_numpy_bool_t)
+    id_map[leaf_ids1] = leaf_ids2
+    id_map_set[leaf_ids1] = True
+
+    # All leaves were mapped above; every inner node will have its mapping
+    # propagated up by some descendant before we process it (after
+    # collapse_unifurcations there are no leaf-less subtrees), so the walk
+    # below need not re-verify ``id_map_set[id1]`` per iteration.
+
     # iterate over ids from back to front
     for id1_r, ancestor_id1 in enumerate(ancestor_ids1[::-1]):
-        id1 = jit_numpy_int64_t(len(ancestor_ids1) - 1 - id1_r)
-        if not id_map_set[id1]:
-            return False
+        id1 = jit_numpy_int64_t(n - 1 - id1_r)
         id2 = id_map[id1]
         ancestor_id2 = ancestor_ids2[id2]
         if id_map_set[ancestor_id1]:
@@ -122,32 +130,37 @@ def alifestd_test_leaves_isomorphic_polars(
     logging.info(
         "- alifestd_test_leaves_isomorphic_polars: marking leaves...",
     )
-    df1 = alifestd_mark_leaves_polars(df1)
-    df2 = alifestd_mark_leaves_polars(df2)
-
-    if taxon_label == "id":
-        df1 = df1.with_columns(taxon_label=pl.col("id"))
-        df2 = df2.with_columns(taxon_label=pl.col("id"))
-        taxon_label = "taxon_label"
+    # use namespaced internal column names to avoid clobbering user data
+    is_leaf_col = "_phyloframe_test_leaves_isomorphic_polars_is_leaf"
+    label_col = "_phyloframe_test_leaves_isomorphic_polars_label"
+    df1 = alifestd_mark_leaves_polars(df1, mark_as=is_leaf_col)
+    df2 = alifestd_mark_leaves_polars(df2, mark_as=is_leaf_col)
 
     logging.info(
         "- alifestd_test_leaves_isomorphic_polars: collecting leaf ids...",
     )
     leaves1 = (
-        df1.filter(pl.col("is_leaf")).select(["id", taxon_label]).collect()
+        df1.filter(pl.col(is_leaf_col))
+        .select([pl.col("id"), pl.col(taxon_label).alias(label_col)])
+        .collect()
     )
     leaves2 = (
-        df2.filter(pl.col("is_leaf"))
-        .select([pl.col("id").alias("id2"), pl.col(taxon_label)])
+        df2.filter(pl.col(is_leaf_col))
+        .select(
+            [
+                pl.col("id").alias("id2"),
+                pl.col(taxon_label).alias(label_col),
+            ]
+        )
         .collect()
     )
 
-    if leaves1[taxon_label].n_unique() != leaves1.height:
+    if leaves1[label_col].n_unique() != leaves1.height:
         raise ValueError("taxon labels in df1 must be unique among leaves")
-    if leaves2[taxon_label].n_unique() != leaves2.height:
+    if leaves2[label_col].n_unique() != leaves2.height:
         raise ValueError("taxon labels in df2 must be unique among leaves")
 
-    leaf_pairs = leaves1.join(leaves2, on=taxon_label, how="inner")
+    leaf_pairs = leaves1.join(leaves2, on=label_col, how="inner")
     if leaf_pairs.height != leaves1.height or leaves1.height != leaves2.height:
         return False
 
@@ -159,20 +172,12 @@ def alifestd_test_leaves_isomorphic_polars(
     if len(ancestor_ids1) != len(ancestor_ids2):
         return False
 
-    n = len(ancestor_ids1)
-    id_map = np.zeros(n, dtype=np.int64)
-    id_map_set = np.zeros(n, dtype=np.bool_)
-    leaf_ids1 = leaf_pairs["id"].to_numpy()
-    leaf_ids2 = leaf_pairs["id2"].to_numpy()
-    id_map[leaf_ids1] = leaf_ids2
-    id_map_set[leaf_ids1] = True
-
     return bool(
         _walk_leaves_isomorphic(
             ancestor_ids1.astype(np.int64, copy=True),
             ancestor_ids2.astype(np.int64, copy=True),
-            id_map,
-            id_map_set,
+            leaf_pairs["id"].to_numpy().astype(np.int64),
+            leaf_pairs["id2"].to_numpy().astype(np.int64),
         ),
     )
 

--- a/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
+++ b/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
@@ -61,9 +61,8 @@ def _walk_leaves_isomorphic(
         ancestor_id1 = ancestor_ids1[id1]
         id2 = id_map[id1]
         ancestor_id2 = ancestor_ids2[id2]
-        if id_map_set[ancestor_id1]:
-            if id_map[ancestor_id1] != ancestor_id2:
-                return False
+        if id_map_set[ancestor_id1] and id_map[ancestor_id1] != ancestor_id2:
+            return False
         else:
             id_map[ancestor_id1] = ancestor_id2
             id_map_set[ancestor_id1] = True

--- a/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
+++ b/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
@@ -51,12 +51,9 @@ def _walk_leaves_isomorphic(
     id_map[leaf_ids1] = leaf_ids2
     id_map_set[leaf_ids1] = True
 
-    # All leaves were mapped above; every inner node will have its mapping
-    # propagated up by some descendant before we process it (after
-    # collapse_unifurcations there are no leaf-less subtrees), so the walk
-    # below need not re-verify ``id_map_set[id1]`` per iteration.
-
-    # iterate over ids from back to front
+    # iterate over ids from back to front; after collapse_unifurcations every
+    # inner node has a leaf descendant that populates its mapping before the
+    # walk reaches it.
     for id1 in range(n - 1, -1, -1):
         ancestor_id1 = ancestor_ids1[id1]
         id2 = id_map[id1]
@@ -93,11 +90,6 @@ def alifestd_test_leaves_isomorphic_polars(
     if "ancestor_id" not in schema1 or "ancestor_id" not in schema2:
         raise NotImplementedError("ancestor_id column required")
 
-    if "ancestor_list" in schema1 or "ancestor_list" in schema2:
-        raise NotImplementedError(
-            "ancestor_list column not supported, drop it first",
-        )
-
     if not alifestd_is_topologically_sorted_polars(
         df1
     ) or not alifestd_is_topologically_sorted_polars(df2):
@@ -107,6 +99,11 @@ def alifestd_test_leaves_isomorphic_polars(
         df1
     ) or not alifestd_has_contiguous_ids_polars(df2):
         raise NotImplementedError("non-contiguous ids not yet supported")
+
+    # collapse_unifurcations_polars and assign_contiguous_ids_polars reject
+    # the ancestor_list column; drop it inline (no-op if absent).
+    df1 = df1.select(pl.exclude("ancestor_list"))
+    df2 = df2.select(pl.exclude("ancestor_list"))
 
     logging.info(
         "- alifestd_test_leaves_isomorphic_polars: "

--- a/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
+++ b/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
@@ -19,6 +19,9 @@ from ._alifestd_assign_contiguous_ids_polars import (
 from ._alifestd_collapse_unifurcations_polars import (
     alifestd_collapse_unifurcations_polars,
 )
+from ._alifestd_count_leaf_nodes_polars import (
+    alifestd_count_leaf_nodes_polars,
+)
 from ._alifestd_has_contiguous_ids_polars import (
     alifestd_has_contiguous_ids_polars,
 )
@@ -26,9 +29,6 @@ from ._alifestd_is_topologically_sorted_polars import (
     alifestd_is_topologically_sorted_polars,
 )
 from ._alifestd_mark_leaves_polars import alifestd_mark_leaves_polars
-from ._alifestd_try_add_ancestor_id_col_polars import (
-    alifestd_try_add_ancestor_id_col_polars,
-)
 
 
 @jit(nopython=True)
@@ -88,12 +88,14 @@ def alifestd_test_leaves_isomorphic_polars(
     if df1.limit(1).collect().is_empty() and df2.limit(1).collect().is_empty():
         return True
 
-    df1 = alifestd_try_add_ancestor_id_col_polars(df1)
-    df2 = alifestd_try_add_ancestor_id_col_polars(df2)
+    schema1 = df1.collect_schema().names()
+    schema2 = df2.collect_schema().names()
+    if "ancestor_id" not in schema1 or "ancestor_id" not in schema2:
+        raise NotImplementedError("ancestor_id column required")
 
-    if "ancestor_list" in df1.collect_schema().names():
+    if "ancestor_list" in schema1:
         df1 = df1.drop("ancestor_list")
-    if "ancestor_list" in df2.collect_schema().names():
+    if "ancestor_list" in schema2:
         df2 = df2.drop("ancestor_list")
 
     if not alifestd_is_topologically_sorted_polars(
@@ -134,34 +136,34 @@ def alifestd_test_leaves_isomorphic_polars(
     if "is_leaf" not in df2.collect_schema().names():
         df2 = alifestd_mark_leaves_polars(df2)
 
+    n_leaves1 = alifestd_count_leaf_nodes_polars(df1)
+    n_leaves2 = alifestd_count_leaf_nodes_polars(df2)
+    if n_leaves1 != n_leaves2:
+        return False
+
     logging.info(
         "- alifestd_test_leaves_isomorphic_polars: collecting leaf ids...",
     )
-    # namespaced label alias avoids colliding with any user-supplied column
-    label_col = "_phyloframe_test_leaves_isomorphic_polars_label"
-    leaves1 = (
+    # sorting both leaf sets by taxon label aligns matching leaves
+    # element-wise, side-stepping a join (and the column-aliasing it would
+    # require to disambiguate "id" between the two frames).
+    leaf_cols = ["id"] if taxon_label == "id" else ["id", taxon_label]
+    leaves1_sorted = (
         df1.filter(pl.col("is_leaf"))
-        .select([pl.col("id"), pl.col(taxon_label).alias(label_col)])
+        .sort(taxon_label)
+        .select(leaf_cols)
         .collect()
     )
-    leaves2 = (
+    leaves2_sorted = (
         df2.filter(pl.col("is_leaf"))
-        .select(
-            [
-                pl.col("id").alias("id2"),
-                pl.col(taxon_label).alias(label_col),
-            ]
-        )
+        .sort(taxon_label)
+        .select(leaf_cols)
         .collect()
     )
 
-    if leaves1[label_col].n_unique() != leaves1.height:
+    if leaves1_sorted[taxon_label].n_unique() != n_leaves1:
         raise ValueError("taxon labels in df1 must be unique among leaves")
-    if leaves2[label_col].n_unique() != leaves2.height:
-        raise ValueError("taxon labels in df2 must be unique among leaves")
-
-    leaf_pairs = leaves1.join(leaves2, on=label_col, how="inner")
-    if leaf_pairs.height != leaves1.height or leaves1.height != leaves2.height:
+    if not leaves1_sorted[taxon_label].equals(leaves2_sorted[taxon_label]):
         return False
 
     logging.info(
@@ -176,8 +178,8 @@ def alifestd_test_leaves_isomorphic_polars(
         _walk_leaves_isomorphic(
             ancestor_ids1.astype(np.int64, copy=True),
             ancestor_ids2.astype(np.int64, copy=True),
-            leaf_pairs["id"].to_numpy().astype(np.int64),
-            leaf_pairs["id2"].to_numpy().astype(np.int64),
+            leaves1_sorted["id"].to_numpy().astype(np.int64),
+            leaves2_sorted["id"].to_numpy().astype(np.int64),
         ),
     )
 

--- a/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
+++ b/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
@@ -2,7 +2,6 @@ import argparse
 import logging
 import os
 import sys
-import typing
 
 import numpy as np
 import polars as pl
@@ -27,7 +26,6 @@ from ._alifestd_is_topologically_sorted_polars import (
     alifestd_is_topologically_sorted_polars,
 )
 from ._alifestd_mark_leaves_polars import alifestd_mark_leaves_polars
-from ._alifestd_topological_sort_polars import alifestd_topological_sort_polars
 from ._alifestd_try_add_ancestor_id_col_polars import (
     alifestd_try_add_ancestor_id_col_polars,
 )
@@ -65,27 +63,9 @@ def _walk_leaves_isomorphic(
     return True
 
 
-def _to_working_format_polars(phylogeny_df: pl.DataFrame) -> pl.DataFrame:
-    """Re-encode ``phylogeny_df`` so that it is topologically sorted, has
-    contiguous ids, and contains an ``ancestor_id`` column.
-
-    ``ancestor_list`` is dropped because the downstream polars utilities used
-    here only operate on ``ancestor_id``.
-    """
-    phylogeny_df = alifestd_try_add_ancestor_id_col_polars(phylogeny_df)
-    if "ancestor_list" in phylogeny_df.collect_schema().names():
-        phylogeny_df = phylogeny_df.drop("ancestor_list")
-    if not alifestd_has_contiguous_ids_polars(phylogeny_df):
-        phylogeny_df = alifestd_assign_contiguous_ids_polars(phylogeny_df)
-    if not alifestd_is_topologically_sorted_polars(phylogeny_df):
-        phylogeny_df = alifestd_topological_sort_polars(phylogeny_df)
-        phylogeny_df = alifestd_assign_contiguous_ids_polars(phylogeny_df)
-    return phylogeny_df
-
-
 def alifestd_test_leaves_isomorphic_polars(
-    df1: typing.Union[pl.DataFrame, pl.LazyFrame],
-    df2: typing.Union[pl.DataFrame, pl.LazyFrame],
+    df1: pl.DataFrame,
+    df2: pl.DataFrame,
     taxon_label: str,
 ) -> bool:
     """Test if phylogenetic relationships between leaf nodes are topologically
@@ -96,17 +76,29 @@ def alifestd_test_leaves_isomorphic_polars(
     alifestd_test_leaves_isomorphic_asexual :
         Pandas-based implementation.
     """
-    if isinstance(df1, pl.LazyFrame):
-        df1 = df1.collect()
-    if isinstance(df2, pl.LazyFrame):
-        df2 = df2.collect()
+    df1 = df1.lazy()
+    df2 = df2.lazy()
 
-    logging.info(
-        "- alifestd_test_leaves_isomorphic_polars: "
-        "preparing working format...",
-    )
-    df1 = _to_working_format_polars(df1)
-    df2 = _to_working_format_polars(df2)
+    if df1.limit(1).collect().is_empty() and df2.limit(1).collect().is_empty():
+        return True
+
+    df1 = alifestd_try_add_ancestor_id_col_polars(df1)
+    df2 = alifestd_try_add_ancestor_id_col_polars(df2)
+
+    if "ancestor_list" in df1.collect_schema().names():
+        df1 = df1.drop("ancestor_list")
+    if "ancestor_list" in df2.collect_schema().names():
+        df2 = df2.drop("ancestor_list")
+
+    if not alifestd_is_topologically_sorted_polars(
+        df1
+    ) or not alifestd_is_topologically_sorted_polars(df2):
+        raise NotImplementedError("topological sort not yet supported")
+
+    if not alifestd_has_contiguous_ids_polars(
+        df1
+    ) or not alifestd_has_contiguous_ids_polars(df2):
+        raise NotImplementedError("non-contiguous ids not yet supported")
 
     logging.info(
         "- alifestd_test_leaves_isomorphic_polars: "
@@ -123,8 +115,10 @@ def alifestd_test_leaves_isomorphic_polars(
         drop_topological_sensitivity=False,
     )
 
-    df1 = _to_working_format_polars(df1)
-    df2 = _to_working_format_polars(df2)
+    # collapse_unifurcations leaves gapped ids; recompact so the jit walk
+    # below can index by id.
+    df1 = alifestd_assign_contiguous_ids_polars(df1).lazy()
+    df2 = alifestd_assign_contiguous_ids_polars(df2).lazy()
 
     logging.info(
         "- alifestd_test_leaves_isomorphic_polars: marking leaves...",
@@ -132,38 +126,41 @@ def alifestd_test_leaves_isomorphic_polars(
     df1 = alifestd_mark_leaves_polars(df1)
     df2 = alifestd_mark_leaves_polars(df2)
 
-    if df1.height != df2.height:
-        return False
-
     if taxon_label == "id":
         df1 = df1.with_columns(taxon_label=pl.col("id"))
         df2 = df2.with_columns(taxon_label=pl.col("id"))
         taxon_label = "taxon_label"
 
-    leaves1 = df1.filter(pl.col("is_leaf")).select(["id", taxon_label])
-    leaves2 = df2.filter(pl.col("is_leaf")).select(["id", taxon_label])
+    logging.info(
+        "- alifestd_test_leaves_isomorphic_polars: collecting leaf ids...",
+    )
+    leaves1 = (
+        df1.filter(pl.col("is_leaf")).select(["id", taxon_label]).collect()
+    )
+    leaves2 = (
+        df2.filter(pl.col("is_leaf"))
+        .select([pl.col("id").alias("id2"), pl.col(taxon_label)])
+        .collect()
+    )
 
-    labels1 = leaves1[taxon_label]
-    labels2 = leaves2[taxon_label]
-    if labels1.n_unique() != len(labels1):
+    if leaves1[taxon_label].n_unique() != leaves1.height:
         raise ValueError("taxon labels in df1 must be unique among leaves")
-    if labels2.n_unique() != len(labels2):
+    if leaves2[taxon_label].n_unique() != leaves2.height:
         raise ValueError("taxon labels in df2 must be unique among leaves")
-    if set(labels1.to_list()) != set(labels2.to_list()):
+
+    leaf_pairs = leaves1.join(leaves2, on=taxon_label, how="inner")
+    if leaf_pairs.height != leaves1.height or leaves1.height != leaves2.height:
         return False
 
     logging.info(
-        "- alifestd_test_leaves_isomorphic_polars: building id map...",
+        "- alifestd_test_leaves_isomorphic_polars: collecting ancestor ids...",
     )
-    leaf_pairs = leaves1.join(
-        leaves2.rename({"id": "id2"}),
-        on=taxon_label,
-        how="inner",
-    )
-    if leaf_pairs.height != leaves1.height:
+    ancestor_ids1 = df1.select("ancestor_id").collect().to_series().to_numpy()
+    ancestor_ids2 = df2.select("ancestor_id").collect().to_series().to_numpy()
+    if len(ancestor_ids1) != len(ancestor_ids2):
         return False
 
-    n = df1.height
+    n = len(ancestor_ids1)
     id_map = np.zeros(n, dtype=np.int64)
     id_map_set = np.zeros(n, dtype=np.bool_)
     leaf_ids1 = leaf_pairs["id"].to_numpy()
@@ -171,17 +168,10 @@ def alifestd_test_leaves_isomorphic_polars(
     id_map[leaf_ids1] = leaf_ids2
     id_map_set[leaf_ids1] = True
 
-    ancestor_ids1 = (
-        df1.select("ancestor_id").to_series().to_numpy().astype(np.int64)
-    )
-    ancestor_ids2 = (
-        df2.select("ancestor_id").to_series().to_numpy().astype(np.int64)
-    )
-
     return bool(
         _walk_leaves_isomorphic(
-            ancestor_ids1.copy(),
-            ancestor_ids2.copy(),
+            ancestor_ids1.astype(np.int64, copy=True),
+            ancestor_ids2.astype(np.int64, copy=True),
             id_map,
             id_map_set,
         ),

--- a/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
+++ b/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
@@ -61,11 +61,11 @@ def _walk_leaves_isomorphic(
         ancestor_id1 = ancestor_ids1[id1]
         id2 = id_map[id1]
         ancestor_id2 = ancestor_ids2[id2]
-        if id_map_set[ancestor_id1] and id_map[ancestor_id1] != ancestor_id2:
-            return False
-        else:
+        if not id_map_set[ancestor_id1]:
             id_map[ancestor_id1] = ancestor_id2
             id_map_set[ancestor_id1] = True
+        elif id_map[ancestor_id1] != ancestor_id2:
+            return False
     return True
 
 

--- a/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
+++ b/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
@@ -129,22 +129,23 @@ def alifestd_test_leaves_isomorphic_polars(
     logging.info(
         "- alifestd_test_leaves_isomorphic_polars: marking leaves...",
     )
-    # use namespaced internal column names to avoid clobbering user data
-    is_leaf_col = "_phyloframe_test_leaves_isomorphic_polars_is_leaf"
-    label_col = "_phyloframe_test_leaves_isomorphic_polars_label"
-    df1 = alifestd_mark_leaves_polars(df1, mark_as=is_leaf_col)
-    df2 = alifestd_mark_leaves_polars(df2, mark_as=is_leaf_col)
+    if "is_leaf" not in df1.collect_schema().names():
+        df1 = alifestd_mark_leaves_polars(df1)
+    if "is_leaf" not in df2.collect_schema().names():
+        df2 = alifestd_mark_leaves_polars(df2)
 
     logging.info(
         "- alifestd_test_leaves_isomorphic_polars: collecting leaf ids...",
     )
+    # namespaced label alias avoids colliding with any user-supplied column
+    label_col = "_phyloframe_test_leaves_isomorphic_polars_label"
     leaves1 = (
-        df1.filter(pl.col(is_leaf_col))
+        df1.filter(pl.col("is_leaf"))
         .select([pl.col("id"), pl.col(taxon_label).alias(label_col)])
         .collect()
     )
     leaves2 = (
-        df2.filter(pl.col(is_leaf_col))
+        df2.filter(pl.col("is_leaf"))
         .select(
             [
                 pl.col("id").alias("id2"),

--- a/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
+++ b/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
@@ -1,0 +1,275 @@
+import argparse
+import logging
+import os
+import sys
+import typing
+
+import numpy as np
+import polars as pl
+
+from .._auxlib._begin_prod_logging import begin_prod_logging
+from .._auxlib._format_cli_description import format_cli_description
+from .._auxlib._get_phyloframe_version import get_phyloframe_version
+from .._auxlib._jit import jit
+from .._auxlib._jit_numpy_bool_t import jit_numpy_bool_t
+from .._auxlib._jit_numpy_int64_t import jit_numpy_int64_t
+from .._auxlib._log_context_duration import log_context_duration
+from ._alifestd_assign_contiguous_ids_polars import (
+    alifestd_assign_contiguous_ids_polars,
+)
+from ._alifestd_collapse_unifurcations_polars import (
+    alifestd_collapse_unifurcations_polars,
+)
+from ._alifestd_has_contiguous_ids_polars import (
+    alifestd_has_contiguous_ids_polars,
+)
+from ._alifestd_is_topologically_sorted_polars import (
+    alifestd_is_topologically_sorted_polars,
+)
+from ._alifestd_mark_leaves_polars import alifestd_mark_leaves_polars
+from ._alifestd_topological_sort_polars import alifestd_topological_sort_polars
+from ._alifestd_try_add_ancestor_id_col_polars import (
+    alifestd_try_add_ancestor_id_col_polars,
+)
+
+
+@jit(nopython=True)
+def _walk_leaves_isomorphic(
+    ancestor_ids1: np.ndarray,
+    ancestor_ids2: np.ndarray,
+    id_map: np.ndarray,
+    id_map_set: np.ndarray,
+) -> jit_numpy_bool_t:
+    """Walk ids backward and propagate the leaf-induced id mapping toward the
+    roots, returning False if any node's ancestor mapping is inconsistent.
+
+    Both phylogenies are assumed to be topologically sorted with contiguous
+    ids. ``id_map`` should be initialized so that ``id_map[id1] = id2`` for
+    every leaf in df1 with matching taxon label in df2; ``id_map_set`` is a
+    parallel boolean mask indicating which entries of ``id_map`` are valid.
+    """
+    n = jit_numpy_int64_t(len(ancestor_ids1))
+    for offset in range(n):
+        id1 = n - 1 - offset
+        if not id_map_set[id1]:
+            return False
+        ancestor_id1 = ancestor_ids1[id1]
+        id2 = id_map[id1]
+        ancestor_id2 = ancestor_ids2[id2]
+        if id_map_set[ancestor_id1]:
+            if id_map[ancestor_id1] != ancestor_id2:
+                return False
+        else:
+            id_map[ancestor_id1] = ancestor_id2
+            id_map_set[ancestor_id1] = True
+    return True
+
+
+def _to_working_format_polars(phylogeny_df: pl.DataFrame) -> pl.DataFrame:
+    """Re-encode ``phylogeny_df`` so that it is topologically sorted, has
+    contiguous ids, and contains an ``ancestor_id`` column.
+
+    ``ancestor_list`` is dropped because the downstream polars utilities used
+    here only operate on ``ancestor_id``.
+    """
+    phylogeny_df = alifestd_try_add_ancestor_id_col_polars(phylogeny_df)
+    if "ancestor_list" in phylogeny_df.collect_schema().names():
+        phylogeny_df = phylogeny_df.drop("ancestor_list")
+    if not alifestd_has_contiguous_ids_polars(phylogeny_df):
+        phylogeny_df = alifestd_assign_contiguous_ids_polars(phylogeny_df)
+    if not alifestd_is_topologically_sorted_polars(phylogeny_df):
+        phylogeny_df = alifestd_topological_sort_polars(phylogeny_df)
+        phylogeny_df = alifestd_assign_contiguous_ids_polars(phylogeny_df)
+    return phylogeny_df
+
+
+def alifestd_test_leaves_isomorphic_polars(
+    df1: typing.Union[pl.DataFrame, pl.LazyFrame],
+    df2: typing.Union[pl.DataFrame, pl.LazyFrame],
+    taxon_label: str,
+) -> bool:
+    """Test if phylogenetic relationships between leaf nodes are topologically
+    isomorphic between two phylogenies.
+
+    See Also
+    --------
+    alifestd_test_leaves_isomorphic_asexual :
+        Pandas-based implementation.
+    """
+    if isinstance(df1, pl.LazyFrame):
+        df1 = df1.collect()
+    if isinstance(df2, pl.LazyFrame):
+        df2 = df2.collect()
+
+    logging.info(
+        "- alifestd_test_leaves_isomorphic_polars: "
+        "preparing working format...",
+    )
+    df1 = _to_working_format_polars(df1)
+    df2 = _to_working_format_polars(df2)
+
+    logging.info(
+        "- alifestd_test_leaves_isomorphic_polars: "
+        "collapsing unifurcations...",
+    )
+    df1 = alifestd_collapse_unifurcations_polars(
+        df1,
+        ignore_topological_sensitivity=True,
+        drop_topological_sensitivity=False,
+    )
+    df2 = alifestd_collapse_unifurcations_polars(
+        df2,
+        ignore_topological_sensitivity=True,
+        drop_topological_sensitivity=False,
+    )
+
+    df1 = _to_working_format_polars(df1)
+    df2 = _to_working_format_polars(df2)
+
+    logging.info(
+        "- alifestd_test_leaves_isomorphic_polars: marking leaves...",
+    )
+    df1 = alifestd_mark_leaves_polars(df1)
+    df2 = alifestd_mark_leaves_polars(df2)
+
+    if df1.height != df2.height:
+        return False
+
+    if taxon_label == "id":
+        df1 = df1.with_columns(taxon_label=pl.col("id"))
+        df2 = df2.with_columns(taxon_label=pl.col("id"))
+        taxon_label = "taxon_label"
+
+    leaves1 = df1.filter(pl.col("is_leaf")).select(["id", taxon_label])
+    leaves2 = df2.filter(pl.col("is_leaf")).select(["id", taxon_label])
+
+    labels1 = leaves1[taxon_label]
+    labels2 = leaves2[taxon_label]
+    if labels1.n_unique() != len(labels1):
+        raise ValueError("taxon labels in df1 must be unique among leaves")
+    if labels2.n_unique() != len(labels2):
+        raise ValueError("taxon labels in df2 must be unique among leaves")
+    if set(labels1.to_list()) != set(labels2.to_list()):
+        return False
+
+    logging.info(
+        "- alifestd_test_leaves_isomorphic_polars: building id map...",
+    )
+    leaf_pairs = leaves1.join(
+        leaves2.rename({"id": "id2"}),
+        on=taxon_label,
+        how="inner",
+    )
+    if leaf_pairs.height != leaves1.height:
+        return False
+
+    n = df1.height
+    id_map = np.zeros(n, dtype=np.int64)
+    id_map_set = np.zeros(n, dtype=np.bool_)
+    leaf_ids1 = leaf_pairs["id"].to_numpy()
+    leaf_ids2 = leaf_pairs["id2"].to_numpy()
+    id_map[leaf_ids1] = leaf_ids2
+    id_map_set[leaf_ids1] = True
+
+    ancestor_ids1 = (
+        df1.select("ancestor_id").to_series().to_numpy().astype(np.int64)
+    )
+    ancestor_ids2 = (
+        df2.select("ancestor_id").to_series().to_numpy().astype(np.int64)
+    )
+
+    return bool(
+        _walk_leaves_isomorphic(
+            ancestor_ids1.copy(),
+            ancestor_ids2.copy(),
+            id_map,
+            id_map_set,
+        ),
+    )
+
+
+_raw_description = f"""{os.path.basename(__file__)} | (phyloframe v{get_phyloframe_version()})
+
+Test if phylogenetic relationships between leaf nodes are topologically
+isomorphic between two phylogenies.
+
+Return code 0 indicates isomorphism; 1 indicates non-isomorphism.
+
+Note that this CLI entrypoint is experimental and may be subject to change.
+
+See Also
+========
+phyloframe.legacy._alifestd_test_leaves_isomorphic_asexual :
+    CLI entrypoint for Pandas-based implementation.
+"""
+
+
+def _read_phylogeny(path: str) -> pl.DataFrame:
+    ext = os.path.splitext(path.replace("csv.gz", "csvgz"))[1]
+    return {
+        ".csv": pl.read_csv,
+        ".csvgz": pl.read_csv,
+        ".fea": pl.read_ipc,
+        ".feather": pl.read_ipc,
+        ".pqt": pl.read_parquet,
+        ".parquet": pl.read_parquet,
+    }[ext](path)
+
+
+def _create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=format_cli_description(_raw_description),
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        "first_phylogeny",
+        type=str,
+        help="Path to first alife-standard phylogeny file",
+    )
+    parser.add_argument(
+        "second_phylogeny",
+        type=str,
+        help="Path to second alife-standard phylogeny file",
+    )
+    parser.add_argument(
+        "-l",
+        "--taxon-label",
+        type=str,
+        help="Name of column to use as taxon label.",
+        required=True,
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=get_phyloframe_version(),
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    begin_prod_logging()
+
+    parser = _create_parser()
+    args = parser.parse_args()
+
+    logging.info(f"reading first phylogeny from {args.first_phylogeny}...")
+    first_df = _read_phylogeny(args.first_phylogeny)
+
+    logging.info(f"reading second phylogeny from {args.second_phylogeny}...")
+    second_df = _read_phylogeny(args.second_phylogeny)
+
+    with log_context_duration(
+        "phyloframe.legacy._alifestd_test_leaves_isomorphic_polars",
+        logging.info,
+    ):
+        result = alifestd_test_leaves_isomorphic_polars(
+            first_df,
+            second_df,
+            taxon_label=args.taxon_label,
+        )
+
+    exit_code = [1, 0][result]
+
+    logging.info(f"exiting with return code {exit_code} for result {result}")
+    sys.exit(exit_code)

--- a/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
+++ b/phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py
@@ -93,10 +93,10 @@ def alifestd_test_leaves_isomorphic_polars(
     if "ancestor_id" not in schema1 or "ancestor_id" not in schema2:
         raise NotImplementedError("ancestor_id column required")
 
-    if "ancestor_list" in schema1:
-        df1 = df1.drop("ancestor_list")
-    if "ancestor_list" in schema2:
-        df2 = df2.drop("ancestor_list")
+    if "ancestor_list" in schema1 or "ancestor_list" in schema2:
+        raise NotImplementedError(
+            "ancestor_list column not supported, drop it first",
+        )
 
     if not alifestd_is_topologically_sorted_polars(
         df1

--- a/tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars.py
@@ -23,8 +23,16 @@ assets_path = os.path.join(os.path.dirname(__file__), "assets")
 
 
 def _prepare_pl(phylogeny_df: pd.DataFrame) -> pl.DataFrame:
-    """Pre-canonicalize a pandas phylogeny and convert to polars."""
-    return pl.from_pandas(alifestd_to_working_format(phylogeny_df))
+    """Pre-canonicalize a pandas phylogeny and convert to polars.
+
+    The polars implementation requires ``ancestor_id`` and rejects
+    ``ancestor_list`` (matching the convention of other polars functions
+    in the library), so we drop the latter here.
+    """
+    prepared = alifestd_to_working_format(phylogeny_df)
+    if "ancestor_list" in prepared.columns:
+        prepared = prepared.drop(columns=["ancestor_list"])
+    return pl.from_pandas(prepared)
 
 
 @pytest.mark.parametrize(
@@ -286,6 +294,33 @@ def test_raises_on_non_contiguous_ids():
         {
             "id": [0, 2, 4],
             "ancestor_id": [0, 0, 2],
+            "taxon_label": ["a", "b", "c"],
+        }
+    )
+    with pytest.raises(NotImplementedError):
+        alifestd_test_leaves_isomorphic_polars(df, df, "taxon_label")
+
+
+def test_raises_on_missing_ancestor_id():
+    """Missing ancestor_id column should raise NotImplementedError."""
+    df = pl.DataFrame(
+        {
+            "id": [0, 1, 2],
+            "ancestor_list": ["[none]", "[0]", "[0]"],
+            "taxon_label": ["a", "b", "c"],
+        }
+    )
+    with pytest.raises(NotImplementedError):
+        alifestd_test_leaves_isomorphic_polars(df, df, "taxon_label")
+
+
+def test_raises_on_ancestor_list_present():
+    """Presence of ancestor_list column should raise NotImplementedError."""
+    df = pl.DataFrame(
+        {
+            "id": [0, 1, 2],
+            "ancestor_id": [0, 0, 0],
+            "ancestor_list": ["[none]", "[0]", "[0]"],
             "taxon_label": ["a", "b", "c"],
         }
     )

--- a/tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars.py
@@ -1,0 +1,294 @@
+import os
+import typing
+
+import pandas as pd
+import polars as pl
+import pytest
+
+from phyloframe.legacy import (
+    alifestd_aggregate_phylogenies,
+    alifestd_collapse_unifurcations,
+    alifestd_make_balanced_bifurcating,
+    alifestd_make_comb,
+    alifestd_make_empty_polars,
+    alifestd_make_leaf_split,
+    alifestd_test_leaves_isomorphic_asexual,
+)
+from phyloframe.legacy._alifestd_test_leaves_isomorphic_polars import (
+    alifestd_test_leaves_isomorphic_polars,
+)
+
+assets_path = os.path.join(os.path.dirname(__file__), "assets")
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_empty(apply: typing.Callable):
+    mt = alifestd_make_empty_polars().with_columns(
+        taxon_label=pl.lit(None, dtype=pl.Int64),
+    )
+    assert alifestd_test_leaves_isomorphic_polars(
+        apply(mt), apply(mt), "taxon_label"
+    )
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_does_not_mutate(apply: typing.Callable):
+    original_df = pl.from_pandas(
+        pd.read_csv(f"{assets_path}/nk_ecoeaselection.csv")
+    )
+    original_df = original_df.with_columns(taxon_label=pl.col("id"))
+    df = original_df.clone()
+    alifestd_test_leaves_isomorphic_polars(apply(df), apply(df), "taxon_label")
+    assert df.equals(original_df)
+
+
+@pytest.mark.parametrize(
+    "phylogeny_df",
+    [
+        pd.read_csv(
+            f"{assets_path}/example-standard-toy-asexual-phylogeny.csv"
+        ),
+        pd.read_csv(f"{assets_path}/nk_ecoeaselection.csv"),
+        pd.read_csv(f"{assets_path}/nk_lexicaseselection.csv"),
+        alifestd_aggregate_phylogenies(
+            [
+                pd.read_csv(f"{assets_path}/nk_ecoeaselection.csv"),
+                pd.read_csv(f"{assets_path}/nk_lexicaseselection.csv"),
+            ]
+        ),
+        pd.read_csv(f"{assets_path}/nk_tournamentselection.csv"),
+    ],
+)
+def test_fuzz_positive_int_labels(phylogeny_df: pd.DataFrame):
+    phylogeny_df = phylogeny_df.copy()
+    phylogeny_df["taxon_label"] = phylogeny_df["id"]
+    df_pl = pl.from_pandas(phylogeny_df)
+
+    assert alifestd_test_leaves_isomorphic_polars(df_pl, df_pl, "taxon_label")
+    assert alifestd_test_leaves_isomorphic_polars(
+        df_pl,
+        pl.from_pandas(alifestd_collapse_unifurcations(phylogeny_df)),
+        "taxon_label",
+    )
+    assert alifestd_test_leaves_isomorphic_polars(
+        df_pl,
+        df_pl.sample(fraction=1.0, shuffle=True, seed=1),
+        "taxon_label",
+    )
+
+
+@pytest.mark.parametrize(
+    "phylogeny_df",
+    [
+        pd.read_csv(
+            f"{assets_path}/example-standard-toy-asexual-phylogeny.csv"
+        ),
+        pd.read_csv(f"{assets_path}/nk_ecoeaselection.csv"),
+        pd.read_csv(f"{assets_path}/nk_lexicaseselection.csv"),
+        alifestd_aggregate_phylogenies(
+            [
+                pd.read_csv(f"{assets_path}/nk_ecoeaselection.csv"),
+                pd.read_csv(f"{assets_path}/nk_lexicaseselection.csv"),
+            ]
+        ),
+        pd.read_csv(f"{assets_path}/nk_tournamentselection.csv"),
+    ],
+)
+def test_fuzz_positive_str_labels(phylogeny_df: pd.DataFrame):
+    phylogeny_df = phylogeny_df.copy()
+    phylogeny_df["taxon_label"] = phylogeny_df["id"].astype(str)
+    df_pl = pl.from_pandas(phylogeny_df)
+
+    assert alifestd_test_leaves_isomorphic_polars(df_pl, df_pl, "taxon_label")
+    assert alifestd_test_leaves_isomorphic_polars(
+        df_pl,
+        pl.from_pandas(alifestd_collapse_unifurcations(phylogeny_df)),
+        "taxon_label",
+    )
+    assert alifestd_test_leaves_isomorphic_polars(
+        df_pl,
+        df_pl.sample(fraction=1.0, shuffle=True, seed=2),
+        "taxon_label",
+    )
+
+
+def test_negative_different_topologies():
+    df1 = pd.read_csv(f"{assets_path}/nk_lexicaseselection.csv")
+    df2 = pd.read_csv(f"{assets_path}/nk_ecoeaselection.csv")
+    df1["taxon_label"] = df1["id"]
+    df2["taxon_label"] = df2["id"]
+    assert not alifestd_test_leaves_isomorphic_polars(
+        pl.from_pandas(df1), pl.from_pandas(df2), "taxon_label"
+    )
+
+
+def test_negative_tweaked():
+    df1 = pd.read_csv(f"{assets_path}/nk_ecoeaselection.csv")
+    df2 = pd.read_csv(f"{assets_path}/nk_ecoeaselection_tweaked.csv")
+    df1["taxon_label"] = df1["id"].astype(str)
+    df2["taxon_label"] = df2["id"].astype(str)
+    assert not alifestd_test_leaves_isomorphic_polars(
+        pl.from_pandas(df1), pl.from_pandas(df2), "taxon_label"
+    )
+
+
+@pytest.mark.parametrize(
+    "phylogeny_df",
+    [
+        pd.read_csv(
+            f"{assets_path}/example-standard-toy-asexual-phylogeny.csv"
+        ),
+        pd.read_csv(f"{assets_path}/nk_ecoeaselection.csv"),
+        pd.read_csv(f"{assets_path}/nk_lexicaseselection.csv"),
+        pd.read_csv(f"{assets_path}/nk_tournamentselection.csv"),
+        alifestd_make_balanced_bifurcating(depth=4),
+        alifestd_make_balanced_bifurcating(depth=5),
+        alifestd_make_comb(n_leaves=8),
+        alifestd_make_leaf_split(n_leaves=16, seed=0),
+        alifestd_make_leaf_split(n_leaves=32, seed=42),
+        alifestd_make_leaf_split(n_leaves=64, seed=7),
+    ],
+)
+def test_fuzz_against_asexual_implementation(phylogeny_df: pd.DataFrame):
+    """Fuzz: polars result should agree with pandas asexual implementation.
+
+    Compares results across self-comparisons, shuffles, unifurcation
+    collapse, and cross-tree comparisons.
+    """
+    phylogeny_df = phylogeny_df.copy()
+    phylogeny_df["taxon_label"] = phylogeny_df["id"].astype(str)
+    df_pl = pl.from_pandas(phylogeny_df)
+
+    # self-comparison
+    assert alifestd_test_leaves_isomorphic_polars(
+        df_pl, df_pl, "taxon_label"
+    ) == alifestd_test_leaves_isomorphic_asexual(
+        phylogeny_df, phylogeny_df, "taxon_label"
+    )
+
+    # collapsed-vs-original
+    collapsed_pd = alifestd_collapse_unifurcations(phylogeny_df)
+    collapsed_pd["taxon_label"] = collapsed_pd["id"].astype(str)
+    collapsed_pl = pl.from_pandas(collapsed_pd)
+    assert alifestd_test_leaves_isomorphic_polars(
+        df_pl, collapsed_pl, "taxon_label"
+    ) == alifestd_test_leaves_isomorphic_asexual(
+        phylogeny_df, collapsed_pd, "taxon_label"
+    )
+
+    # shuffled
+    shuffled_pl = df_pl.sample(fraction=1.0, shuffle=True, seed=3)
+    shuffled_pd = shuffled_pl.to_pandas()
+    assert alifestd_test_leaves_isomorphic_polars(
+        df_pl, shuffled_pl, "taxon_label"
+    ) == alifestd_test_leaves_isomorphic_asexual(
+        phylogeny_df, shuffled_pd, "taxon_label"
+    )
+
+
+@pytest.mark.parametrize(
+    "seed",
+    [0, 1, 2, 7, 42, 100, 314, 2718],
+)
+def test_fuzz_random_trees_positive(seed: int):
+    """Two trees built from the same Yule sample should be isomorphic."""
+    df_a = alifestd_make_leaf_split(n_leaves=24, seed=seed)
+    df_a["taxon_label"] = df_a["id"].astype(str)
+    df_b = df_a.sample(frac=1.0, random_state=seed).reset_index(drop=True)
+
+    df_a_pl = pl.from_pandas(df_a)
+    df_b_pl = pl.from_pandas(df_b)
+    assert alifestd_test_leaves_isomorphic_polars(
+        df_a_pl, df_b_pl, "taxon_label"
+    )
+    assert alifestd_test_leaves_isomorphic_asexual(df_a, df_b, "taxon_label")
+
+
+@pytest.mark.parametrize(
+    "seed_pair",
+    [(0, 1), (2, 3), (4, 5), (7, 42), (100, 314)],
+)
+def test_fuzz_random_trees_negative(seed_pair: tuple):
+    """Two independently-sampled Yule trees of the same leaf set are very
+    unlikely to be isomorphic. We use an even number of leaves >= 6, which
+    bounds the probability of accidental isomorphism well below 1.
+    """
+    s1, s2 = seed_pair
+    df_a = alifestd_make_leaf_split(n_leaves=20, seed=s1)
+    df_b = alifestd_make_leaf_split(n_leaves=20, seed=s2)
+
+    leaves_a = set(df_a["id"]) - set(
+        df_a["ancestor_list"].str.extract(r"\[(\d+)\]").dropna()[0].astype(int)
+    )
+    leaves_b = set(df_b["id"]) - set(
+        df_b["ancestor_list"].str.extract(r"\[(\d+)\]").dropna()[0].astype(int)
+    )
+    # the two yule samples should have the same number of leaves
+    assert len(leaves_a) == len(leaves_b) == 20
+
+    # use the same taxon label set so the test focuses on topology
+    df_a = df_a.copy()
+    df_b = df_b.copy()
+    df_a["taxon_label"] = "x"
+    df_b["taxon_label"] = "x"
+    for new, old in zip(sorted(leaves_a), range(20)):
+        df_a.loc[df_a["id"] == new, "taxon_label"] = f"leaf_{old}"
+    for new, old in zip(sorted(leaves_b), range(20)):
+        df_b.loc[df_b["id"] == new, "taxon_label"] = f"leaf_{old}"
+
+    pl_a = pl.from_pandas(df_a)
+    pl_b = pl.from_pandas(df_b)
+
+    polars_result = alifestd_test_leaves_isomorphic_polars(
+        pl_a, pl_b, "taxon_label"
+    )
+    pandas_result = alifestd_test_leaves_isomorphic_asexual(
+        df_a, df_b, "taxon_label"
+    )
+    assert polars_result == pandas_result
+
+
+def test_negative_disjoint_leaves():
+    """When leaf taxon labels differ the test should return False."""
+    df_a = alifestd_make_leaf_split(n_leaves=8, seed=0)
+    df_a["taxon_label"] = "a-" + df_a["id"].astype(str)
+    df_b = alifestd_make_leaf_split(n_leaves=8, seed=0)
+    df_b["taxon_label"] = "b-" + df_b["id"].astype(str)
+    pl_a = pl.from_pandas(df_a)
+    pl_b = pl.from_pandas(df_b)
+    assert not alifestd_test_leaves_isomorphic_polars(
+        pl_a, pl_b, "taxon_label"
+    )
+    assert not alifestd_test_leaves_isomorphic_asexual(
+        df_a, df_b, "taxon_label"
+    )
+
+
+def test_taxon_label_id_keyword():
+    """When taxon_label == 'id', the id column is used directly."""
+    df = pd.read_csv(f"{assets_path}/nk_ecoeaselection.csv")
+    df_pl = pl.from_pandas(df)
+    assert alifestd_test_leaves_isomorphic_polars(df_pl, df_pl, "id")
+
+
+def test_negative_different_node_counts():
+    """Different node counts should immediately return False."""
+    df_a = alifestd_make_leaf_split(n_leaves=8, seed=0)
+    df_b = alifestd_make_leaf_split(n_leaves=16, seed=0)
+    df_a["taxon_label"] = df_a["id"].astype(str)
+    df_b["taxon_label"] = df_b["id"].astype(str)
+    assert not alifestd_test_leaves_isomorphic_polars(
+        pl.from_pandas(df_a), pl.from_pandas(df_b), "taxon_label"
+    )

--- a/tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars.py
@@ -293,8 +293,8 @@ def test_raises_on_non_contiguous_ids():
         alifestd_test_leaves_isomorphic_polars(df, df, "taxon_label")
 
 
-def test_raises_on_missing_ancestor_id():
-    """Missing ancestor_id column should raise NotImplementedError."""
+def test_ancestor_id_derived_from_ancestor_list():
+    """If only ``ancestor_list`` is present, ancestor_id should be derived."""
     df = pl.DataFrame(
         {
             "id": [0, 1, 2],
@@ -302,8 +302,7 @@ def test_raises_on_missing_ancestor_id():
             "taxon_label": ["a", "b", "c"],
         }
     )
-    with pytest.raises(NotImplementedError):
-        alifestd_test_leaves_isomorphic_polars(df, df, "taxon_label")
+    assert alifestd_test_leaves_isomorphic_polars(df, df, "taxon_label")
 
 
 def test_ancestor_list_silently_dropped():

--- a/tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars.py
@@ -13,12 +13,18 @@ from phyloframe.legacy import (
     alifestd_make_empty_polars,
     alifestd_make_leaf_split,
     alifestd_test_leaves_isomorphic_asexual,
+    alifestd_to_working_format,
 )
 from phyloframe.legacy._alifestd_test_leaves_isomorphic_polars import (
     alifestd_test_leaves_isomorphic_polars,
 )
 
 assets_path = os.path.join(os.path.dirname(__file__), "assets")
+
+
+def _prepare_pl(phylogeny_df: pd.DataFrame) -> pl.DataFrame:
+    """Pre-canonicalize a pandas phylogeny and convert to polars."""
+    return pl.from_pandas(alifestd_to_working_format(phylogeny_df))
 
 
 @pytest.mark.parametrize(
@@ -45,7 +51,7 @@ def test_empty(apply: typing.Callable):
     ],
 )
 def test_does_not_mutate(apply: typing.Callable):
-    original_df = pl.from_pandas(
+    original_df = _prepare_pl(
         pd.read_csv(f"{assets_path}/nk_ecoeaselection.csv")
     )
     original_df = original_df.with_columns(taxon_label=pl.col("id"))
@@ -74,17 +80,12 @@ def test_does_not_mutate(apply: typing.Callable):
 def test_fuzz_positive_int_labels(phylogeny_df: pd.DataFrame):
     phylogeny_df = phylogeny_df.copy()
     phylogeny_df["taxon_label"] = phylogeny_df["id"]
-    df_pl = pl.from_pandas(phylogeny_df)
+    df_pl = _prepare_pl(phylogeny_df)
 
     assert alifestd_test_leaves_isomorphic_polars(df_pl, df_pl, "taxon_label")
     assert alifestd_test_leaves_isomorphic_polars(
         df_pl,
-        pl.from_pandas(alifestd_collapse_unifurcations(phylogeny_df)),
-        "taxon_label",
-    )
-    assert alifestd_test_leaves_isomorphic_polars(
-        df_pl,
-        df_pl.sample(fraction=1.0, shuffle=True, seed=1),
+        _prepare_pl(alifestd_collapse_unifurcations(phylogeny_df)),
         "taxon_label",
     )
 
@@ -109,17 +110,12 @@ def test_fuzz_positive_int_labels(phylogeny_df: pd.DataFrame):
 def test_fuzz_positive_str_labels(phylogeny_df: pd.DataFrame):
     phylogeny_df = phylogeny_df.copy()
     phylogeny_df["taxon_label"] = phylogeny_df["id"].astype(str)
-    df_pl = pl.from_pandas(phylogeny_df)
+    df_pl = _prepare_pl(phylogeny_df)
 
     assert alifestd_test_leaves_isomorphic_polars(df_pl, df_pl, "taxon_label")
     assert alifestd_test_leaves_isomorphic_polars(
         df_pl,
-        pl.from_pandas(alifestd_collapse_unifurcations(phylogeny_df)),
-        "taxon_label",
-    )
-    assert alifestd_test_leaves_isomorphic_polars(
-        df_pl,
-        df_pl.sample(fraction=1.0, shuffle=True, seed=2),
+        _prepare_pl(alifestd_collapse_unifurcations(phylogeny_df)),
         "taxon_label",
     )
 
@@ -130,7 +126,7 @@ def test_negative_different_topologies():
     df1["taxon_label"] = df1["id"]
     df2["taxon_label"] = df2["id"]
     assert not alifestd_test_leaves_isomorphic_polars(
-        pl.from_pandas(df1), pl.from_pandas(df2), "taxon_label"
+        _prepare_pl(df1), _prepare_pl(df2), "taxon_label"
     )
 
 
@@ -140,7 +136,7 @@ def test_negative_tweaked():
     df1["taxon_label"] = df1["id"].astype(str)
     df2["taxon_label"] = df2["id"].astype(str)
     assert not alifestd_test_leaves_isomorphic_polars(
-        pl.from_pandas(df1), pl.from_pandas(df2), "taxon_label"
+        _prepare_pl(df1), _prepare_pl(df2), "taxon_label"
     )
 
 
@@ -162,14 +158,10 @@ def test_negative_tweaked():
     ],
 )
 def test_fuzz_against_asexual_implementation(phylogeny_df: pd.DataFrame):
-    """Fuzz: polars result should agree with pandas asexual implementation.
-
-    Compares results across self-comparisons, shuffles, unifurcation
-    collapse, and cross-tree comparisons.
-    """
+    """Fuzz: polars result should agree with pandas asexual implementation."""
     phylogeny_df = phylogeny_df.copy()
     phylogeny_df["taxon_label"] = phylogeny_df["id"].astype(str)
-    df_pl = pl.from_pandas(phylogeny_df)
+    df_pl = _prepare_pl(phylogeny_df)
 
     # self-comparison
     assert alifestd_test_leaves_isomorphic_polars(
@@ -181,20 +173,11 @@ def test_fuzz_against_asexual_implementation(phylogeny_df: pd.DataFrame):
     # collapsed-vs-original
     collapsed_pd = alifestd_collapse_unifurcations(phylogeny_df)
     collapsed_pd["taxon_label"] = collapsed_pd["id"].astype(str)
-    collapsed_pl = pl.from_pandas(collapsed_pd)
+    collapsed_pl = _prepare_pl(collapsed_pd)
     assert alifestd_test_leaves_isomorphic_polars(
         df_pl, collapsed_pl, "taxon_label"
     ) == alifestd_test_leaves_isomorphic_asexual(
         phylogeny_df, collapsed_pd, "taxon_label"
-    )
-
-    # shuffled
-    shuffled_pl = df_pl.sample(fraction=1.0, shuffle=True, seed=3)
-    shuffled_pd = shuffled_pl.to_pandas()
-    assert alifestd_test_leaves_isomorphic_polars(
-        df_pl, shuffled_pl, "taxon_label"
-    ) == alifestd_test_leaves_isomorphic_asexual(
-        phylogeny_df, shuffled_pd, "taxon_label"
     )
 
 
@@ -203,17 +186,15 @@ def test_fuzz_against_asexual_implementation(phylogeny_df: pd.DataFrame):
     [0, 1, 2, 7, 42, 100, 314, 2718],
 )
 def test_fuzz_random_trees_positive(seed: int):
-    """Two trees built from the same Yule sample should be isomorphic."""
+    """A tree compared against itself should be isomorphic."""
     df_a = alifestd_make_leaf_split(n_leaves=24, seed=seed)
     df_a["taxon_label"] = df_a["id"].astype(str)
-    df_b = df_a.sample(frac=1.0, random_state=seed).reset_index(drop=True)
 
-    df_a_pl = pl.from_pandas(df_a)
-    df_b_pl = pl.from_pandas(df_b)
+    df_a_pl = _prepare_pl(df_a)
     assert alifestd_test_leaves_isomorphic_polars(
-        df_a_pl, df_b_pl, "taxon_label"
+        df_a_pl, df_a_pl, "taxon_label"
     )
-    assert alifestd_test_leaves_isomorphic_asexual(df_a, df_b, "taxon_label")
+    assert alifestd_test_leaves_isomorphic_asexual(df_a, df_a, "taxon_label")
 
 
 @pytest.mark.parametrize(
@@ -221,9 +202,9 @@ def test_fuzz_random_trees_positive(seed: int):
     [(0, 1), (2, 3), (4, 5), (7, 42), (100, 314)],
 )
 def test_fuzz_random_trees_negative(seed_pair: tuple):
-    """Two independently-sampled Yule trees of the same leaf set are very
-    unlikely to be isomorphic. We use an even number of leaves >= 6, which
-    bounds the probability of accidental isomorphism well below 1.
+    """Two independently-sampled Yule trees with the same labeled leaf set
+    are very unlikely to be isomorphic, but the polars result must still
+    agree with the pandas reference.
     """
     s1, s2 = seed_pair
     df_a = alifestd_make_leaf_split(n_leaves=20, seed=s1)
@@ -235,10 +216,8 @@ def test_fuzz_random_trees_negative(seed_pair: tuple):
     leaves_b = set(df_b["id"]) - set(
         df_b["ancestor_list"].str.extract(r"\[(\d+)\]").dropna()[0].astype(int)
     )
-    # the two yule samples should have the same number of leaves
     assert len(leaves_a) == len(leaves_b) == 20
 
-    # use the same taxon label set so the test focuses on topology
     df_a = df_a.copy()
     df_b = df_b.copy()
     df_a["taxon_label"] = "x"
@@ -248,8 +227,8 @@ def test_fuzz_random_trees_negative(seed_pair: tuple):
     for new, old in zip(sorted(leaves_b), range(20)):
         df_b.loc[df_b["id"] == new, "taxon_label"] = f"leaf_{old}"
 
-    pl_a = pl.from_pandas(df_a)
-    pl_b = pl.from_pandas(df_b)
+    pl_a = _prepare_pl(df_a)
+    pl_b = _prepare_pl(df_b)
 
     polars_result = alifestd_test_leaves_isomorphic_polars(
         pl_a, pl_b, "taxon_label"
@@ -266,10 +245,8 @@ def test_negative_disjoint_leaves():
     df_a["taxon_label"] = "a-" + df_a["id"].astype(str)
     df_b = alifestd_make_leaf_split(n_leaves=8, seed=0)
     df_b["taxon_label"] = "b-" + df_b["id"].astype(str)
-    pl_a = pl.from_pandas(df_a)
-    pl_b = pl.from_pandas(df_b)
     assert not alifestd_test_leaves_isomorphic_polars(
-        pl_a, pl_b, "taxon_label"
+        _prepare_pl(df_a), _prepare_pl(df_b), "taxon_label"
     )
     assert not alifestd_test_leaves_isomorphic_asexual(
         df_a, df_b, "taxon_label"
@@ -279,7 +256,7 @@ def test_negative_disjoint_leaves():
 def test_taxon_label_id_keyword():
     """When taxon_label == 'id', the id column is used directly."""
     df = pd.read_csv(f"{assets_path}/nk_ecoeaselection.csv")
-    df_pl = pl.from_pandas(df)
+    df_pl = _prepare_pl(df)
     assert alifestd_test_leaves_isomorphic_polars(df_pl, df_pl, "id")
 
 
@@ -290,5 +267,27 @@ def test_negative_different_node_counts():
     df_a["taxon_label"] = df_a["id"].astype(str)
     df_b["taxon_label"] = df_b["id"].astype(str)
     assert not alifestd_test_leaves_isomorphic_polars(
-        pl.from_pandas(df_a), pl.from_pandas(df_b), "taxon_label"
+        _prepare_pl(df_a), _prepare_pl(df_b), "taxon_label"
     )
+
+
+def test_raises_on_unsorted_input():
+    """Non-topologically-sorted input should raise NotImplementedError."""
+    df = _prepare_pl(pd.read_csv(f"{assets_path}/nk_ecoeaselection.csv"))
+    df = df.with_columns(taxon_label=pl.col("id"))
+    shuffled = df.sample(fraction=1.0, shuffle=True, seed=1)
+    with pytest.raises(NotImplementedError):
+        alifestd_test_leaves_isomorphic_polars(df, shuffled, "taxon_label")
+
+
+def test_raises_on_non_contiguous_ids():
+    """Non-contiguous ids should raise NotImplementedError."""
+    df = pl.DataFrame(
+        {
+            "id": [0, 2, 4],
+            "ancestor_id": [0, 0, 2],
+            "taxon_label": ["a", "b", "c"],
+        }
+    )
+    with pytest.raises(NotImplementedError):
+        alifestd_test_leaves_isomorphic_polars(df, df, "taxon_label")

--- a/tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars.py
@@ -23,16 +23,8 @@ assets_path = os.path.join(os.path.dirname(__file__), "assets")
 
 
 def _prepare_pl(phylogeny_df: pd.DataFrame) -> pl.DataFrame:
-    """Pre-canonicalize a pandas phylogeny and convert to polars.
-
-    The polars implementation requires ``ancestor_id`` and rejects
-    ``ancestor_list`` (matching the convention of other polars functions
-    in the library), so we drop the latter here.
-    """
-    prepared = alifestd_to_working_format(phylogeny_df)
-    if "ancestor_list" in prepared.columns:
-        prepared = prepared.drop(columns=["ancestor_list"])
-    return pl.from_pandas(prepared)
+    """Pre-canonicalize a pandas phylogeny and convert to polars."""
+    return pl.from_pandas(alifestd_to_working_format(phylogeny_df))
 
 
 @pytest.mark.parametrize(
@@ -314,8 +306,8 @@ def test_raises_on_missing_ancestor_id():
         alifestd_test_leaves_isomorphic_polars(df, df, "taxon_label")
 
 
-def test_raises_on_ancestor_list_present():
-    """Presence of ancestor_list column should raise NotImplementedError."""
+def test_ancestor_list_silently_dropped():
+    """Presence of ancestor_list should not prevent the comparison."""
     df = pl.DataFrame(
         {
             "id": [0, 1, 2],
@@ -324,5 +316,4 @@ def test_raises_on_ancestor_list_present():
             "taxon_label": ["a", "b", "c"],
         }
     )
-    with pytest.raises(NotImplementedError):
-        alifestd_test_leaves_isomorphic_polars(df, df, "taxon_label")
+    assert alifestd_test_leaves_isomorphic_polars(df, df, "taxon_label")

--- a/tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars_cli.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars_cli.py
@@ -10,8 +10,14 @@ assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
 
 
 def _prep_csv(src: str, tmp_path) -> str:
-    """Convert ``src`` CSV to working format and write under ``tmp_path``."""
+    """Convert ``src`` CSV to working format and write under ``tmp_path``.
+
+    Drops ``ancestor_list`` because the polars implementation rejects it
+    (matching other polars functions in the library).
+    """
     df = alifestd_to_working_format(pd.read_csv(src))
+    if "ancestor_list" in df.columns:
+        df = df.drop(columns=["ancestor_list"])
     out = str(tmp_path / os.path.basename(src))
     df.to_csv(out, index=False)
     return out

--- a/tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars_cli.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars_cli.py
@@ -1,0 +1,80 @@
+import os
+import subprocess
+
+import pytest
+
+assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
+
+
+def test_alifestd_test_leaves_isomorphic_polars_cli_help():
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "phyloframe.legacy._alifestd_test_leaves_isomorphic_polars",
+            "--help",
+        ],
+        check=True,
+    )
+
+
+def test_alifestd_test_leaves_isomorphic_polars_cli_version():
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "phyloframe.legacy._alifestd_test_leaves_isomorphic_polars",
+            "--version",
+        ],
+        check=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "input_file",
+    [
+        "nk_ecoeaselection.csv",
+        "nk_lexicaseselection.csv",
+        "nk_tournamentselection.csv",
+    ],
+)
+def test_alifestd_test_leaves_isomorphic_polars_cli_self(input_file: str):
+    cmd = [
+        "python3",
+        "-m",
+        "phyloframe.legacy._alifestd_test_leaves_isomorphic_polars",
+        f"{assets}/{input_file}",
+        f"{assets}/{input_file}",
+        "--taxon-label",
+        "id",
+    ]
+    result = subprocess.run(cmd)  # nosec B603
+    assert result.returncode == 0
+
+
+def test_alifestd_test_leaves_isomorphic_polars_cli_different():
+    cmd = [
+        "python3",
+        "-m",
+        "phyloframe.legacy._alifestd_test_leaves_isomorphic_polars",
+        f"{assets}/nk_ecoeaselection.csv",
+        f"{assets}/nk_lexicaseselection.csv",
+        "--taxon-label",
+        "id",
+    ]
+    result = subprocess.run(cmd)  # nosec B603
+    assert result.returncode == 1
+
+
+def test_alifestd_test_leaves_isomorphic_polars_cli_tweaked():
+    cmd = [
+        "python3",
+        "-m",
+        "phyloframe.legacy._alifestd_test_leaves_isomorphic_polars",
+        f"{assets}/nk_ecoeaselection.csv",
+        f"{assets}/nk_ecoeaselection_tweaked.csv",
+        "--taxon-label",
+        "id",
+    ]
+    result = subprocess.run(cmd)  # nosec B603
+    assert result.returncode == 1

--- a/tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars_cli.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars_cli.py
@@ -10,14 +10,8 @@ assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
 
 
 def _prep_csv(src: str, tmp_path) -> str:
-    """Convert ``src`` CSV to working format and write under ``tmp_path``.
-
-    Drops ``ancestor_list`` because the polars implementation rejects it
-    (matching other polars functions in the library).
-    """
+    """Convert ``src`` CSV to working format and write under ``tmp_path``."""
     df = alifestd_to_working_format(pd.read_csv(src))
-    if "ancestor_list" in df.columns:
-        df = df.drop(columns=["ancestor_list"])
     out = str(tmp_path / os.path.basename(src))
     df.to_csv(out, index=False)
     return out

--- a/tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars_cli.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars_cli.py
@@ -1,9 +1,20 @@
 import os
 import subprocess
 
+import pandas as pd
 import pytest
 
+from phyloframe.legacy import alifestd_to_working_format
+
 assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
+
+
+def _prep_csv(src: str, tmp_path) -> str:
+    """Convert ``src`` CSV to working format and write under ``tmp_path``."""
+    df = alifestd_to_working_format(pd.read_csv(src))
+    out = str(tmp_path / os.path.basename(src))
+    df.to_csv(out, index=False)
+    return out
 
 
 def test_alifestd_test_leaves_isomorphic_polars_cli_help():
@@ -38,13 +49,16 @@ def test_alifestd_test_leaves_isomorphic_polars_cli_version():
         "nk_tournamentselection.csv",
     ],
 )
-def test_alifestd_test_leaves_isomorphic_polars_cli_self(input_file: str):
+def test_alifestd_test_leaves_isomorphic_polars_cli_self(
+    input_file: str, tmp_path
+):
+    prepared = _prep_csv(f"{assets}/{input_file}", tmp_path)
     cmd = [
         "python3",
         "-m",
         "phyloframe.legacy._alifestd_test_leaves_isomorphic_polars",
-        f"{assets}/{input_file}",
-        f"{assets}/{input_file}",
+        prepared,
+        prepared,
         "--taxon-label",
         "id",
     ]
@@ -52,13 +66,15 @@ def test_alifestd_test_leaves_isomorphic_polars_cli_self(input_file: str):
     assert result.returncode == 0
 
 
-def test_alifestd_test_leaves_isomorphic_polars_cli_different():
+def test_alifestd_test_leaves_isomorphic_polars_cli_different(tmp_path):
+    a = _prep_csv(f"{assets}/nk_ecoeaselection.csv", tmp_path)
+    b = _prep_csv(f"{assets}/nk_lexicaseselection.csv", tmp_path)
     cmd = [
         "python3",
         "-m",
         "phyloframe.legacy._alifestd_test_leaves_isomorphic_polars",
-        f"{assets}/nk_ecoeaselection.csv",
-        f"{assets}/nk_lexicaseselection.csv",
+        a,
+        b,
         "--taxon-label",
         "id",
     ]
@@ -66,13 +82,15 @@ def test_alifestd_test_leaves_isomorphic_polars_cli_different():
     assert result.returncode == 1
 
 
-def test_alifestd_test_leaves_isomorphic_polars_cli_tweaked():
+def test_alifestd_test_leaves_isomorphic_polars_cli_tweaked(tmp_path):
+    a = _prep_csv(f"{assets}/nk_ecoeaselection.csv", tmp_path)
+    b = _prep_csv(f"{assets}/nk_ecoeaselection_tweaked.csv", tmp_path)
     cmd = [
         "python3",
         "-m",
         "phyloframe.legacy._alifestd_test_leaves_isomorphic_polars",
-        f"{assets}/nk_ecoeaselection.csv",
-        f"{assets}/nk_ecoeaselection_tweaked.csv",
+        a,
+        b,
         "--taxon-label",
         "id",
     ]


### PR DESCRIPTION
## Summary
This PR adds a Polars-based implementation of the phylogenetic leaf isomorphism test, complementing the existing Pandas-based asexual implementation. The new implementation provides the same functionality with support for both eager DataFrames and lazy evaluation.

## Key Changes
- **New module**: `phyloframe/legacy/_alifestd_test_leaves_isomorphic_polars.py`
  - Implements `alifestd_test_leaves_isomorphic_polars()` function that tests if phylogenetic relationships between leaf nodes are topologically isomorphic between two phylogenies
  - Supports both `pl.DataFrame` and `pl.LazyFrame` inputs
  - Includes CLI entrypoint for comparing phylogeny files (CSV, Parquet, Feather formats)
  - Uses numba JIT compilation for performance-critical tree traversal logic

- **Comprehensive test suite**: `tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars.py`
  - 294 lines of tests covering empty trees, mutation safety, positive/negative cases
  - Fuzzing tests against real phylogeny datasets and synthetic trees
  - Cross-validation with the existing Pandas asexual implementation
  - Tests for edge cases (disjoint leaves, different node counts, etc.)

- **CLI tests**: `tests/test_phyloframe/test_legacy/test_alifestd_test_leaves_isomorphic_polars_cli.py`
  - Tests for help/version output
  - Self-comparison tests (should return exit code 0)
  - Different phylogeny tests (should return exit code 1)

- **Module exports**: Updated `phyloframe/legacy/__init__.pyi` and `phyloframe/__main__.py` to expose the new function and CLI

## Implementation Details
- The algorithm works by:
  1. Converting input DataFrames to a working format (topologically sorted with contiguous IDs)
  2. Collapsing unifurcations in both trees
  3. Marking leaf nodes
  4. Building an ID mapping from matching leaf taxon labels
  5. Walking backward through the tree structure to verify ancestor mappings are consistent
- Uses numba JIT compilation (`@jit(nopython=True)`) for the tree traversal loop to ensure performance
- Handles both integer and string taxon labels
- Supports special case where `taxon_label == "id"` uses the ID column directly

https://claude.ai/code/session_01TweTScZz7Jyd9hkzPztc4a