### PR TITLE
Add alifestd_to_working_format_polars

### DIFF
--- a/phyloframe/__main__.py
+++ b/phyloframe/__main__.py
@@ -160,6 +160,7 @@ $ python3 -m phyloframe.legacy._alifestd_splay_polytomies
 $ python3 -m phyloframe.legacy._alifestd_splay_polytomies_polars
 $ python3 -m phyloframe.legacy._alifestd_test_leaves_isomorphic_asexual
 $ python3 -m phyloframe.legacy._alifestd_to_working_format
+$ python3 -m phyloframe.legacy._alifestd_to_working_format_polars
 $ python3 -m phyloframe.legacy._alifestd_topological_sort
 $ python3 -m phyloframe.legacy._alifestd_topological_sort_polars
 $ python3 -m phyloframe.legacy._alifestd_try_add_ancestor_id_col

--- a/phyloframe/legacy/__init__.pyi
+++ b/phyloframe/legacy/__init__.pyi
@@ -593,6 +593,9 @@ from ._alifestd_test_leaves_isomorphic_asexual import (
     alifestd_test_leaves_isomorphic_asexual,
 )
 from ._alifestd_to_working_format import alifestd_to_working_format
+from ._alifestd_to_working_format_polars import (
+    alifestd_to_working_format_polars,
+)
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
@@ -930,6 +933,7 @@ __all__ = [
     "alifestd_sum_origin_time_deltas_polars",
     "alifestd_test_leaves_isomorphic_asexual",
     "alifestd_to_working_format",
+    "alifestd_to_working_format_polars",
     "alifestd_topological_sensitivity_warned",
     "alifestd_topological_sensitivity_warned_polars",
     "alifestd_topological_sort",

--- a/phyloframe/legacy/_alifestd_to_working_format_polars.py
+++ b/phyloframe/legacy/_alifestd_to_working_format_polars.py
@@ -61,11 +61,8 @@ def alifestd_to_working_format_polars(
     """
     phylogeny_df = alifestd_try_add_ancestor_id_col_polars(phylogeny_df)
 
-    had_ancestor_list = (
-        "ancestor_list" in phylogeny_df.lazy().collect_schema().names()
-    )
-    if had_ancestor_list:
-        phylogeny_df = phylogeny_df.drop("ancestor_list")
+    schema_names = phylogeny_df.lazy().collect_schema().names()
+    phylogeny_df = phylogeny_df.select(pl.exclude("ancestor_list"))
 
     if not alifestd_has_contiguous_ids_polars(phylogeny_df):
         phylogeny_df = phylogeny_df.pipe(alifestd_assign_contiguous_ids_polars)
@@ -75,7 +72,7 @@ def alifestd_to_working_format_polars(
             alifestd_topological_sort_polars,
         ).pipe(alifestd_assign_contiguous_ids_polars)
 
-    if keep_ancestor_list and had_ancestor_list:
+    if keep_ancestor_list and "ancestor_list" in schema_names:
         phylogeny_df = phylogeny_df.with_columns(
             ancestor_list=alifestd_make_ancestor_list_col_polars(
                 phylogeny_df.lazy().select("id").collect().to_series(),

--- a/phyloframe/legacy/_alifestd_to_working_format_polars.py
+++ b/phyloframe/legacy/_alifestd_to_working_format_polars.py
@@ -49,8 +49,10 @@ def alifestd_to_working_format_polars(
     phylogeny_df : polars.DataFrame
         The phylogeny as a dataframe in alife standard format.
     keep_ancestor_list : bool, default False
-        If True, regenerate the `ancestor_list` column from the (reassigned)
-        `ancestor_id` column. If False, the `ancestor_list` column is dropped.
+        If True and `ancestor_list` was present in the input, regenerate the
+        `ancestor_list` column from the (reassigned) `ancestor_id` column. The
+        column is dropped during processing in all cases; it is only restored
+        when this flag is set and the input already had it.
 
     See Also
     --------
@@ -59,17 +61,21 @@ def alifestd_to_working_format_polars(
     """
     phylogeny_df = alifestd_try_add_ancestor_id_col_polars(phylogeny_df)
 
-    if "ancestor_list" in phylogeny_df.lazy().collect_schema().names():
+    had_ancestor_list = (
+        "ancestor_list" in phylogeny_df.lazy().collect_schema().names()
+    )
+    if had_ancestor_list:
         phylogeny_df = phylogeny_df.drop("ancestor_list")
 
     if not alifestd_has_contiguous_ids_polars(phylogeny_df):
-        phylogeny_df = alifestd_assign_contiguous_ids_polars(phylogeny_df)
+        phylogeny_df = phylogeny_df.pipe(alifestd_assign_contiguous_ids_polars)
 
     if not alifestd_is_topologically_sorted_polars(phylogeny_df):
-        phylogeny_df = alifestd_topological_sort_polars(phylogeny_df)
-        phylogeny_df = alifestd_assign_contiguous_ids_polars(phylogeny_df)
+        phylogeny_df = phylogeny_df.pipe(
+            alifestd_topological_sort_polars,
+        ).pipe(alifestd_assign_contiguous_ids_polars)
 
-    if keep_ancestor_list:
+    if keep_ancestor_list and had_ancestor_list:
         phylogeny_df = phylogeny_df.with_columns(
             ancestor_list=alifestd_make_ancestor_list_col_polars(
                 phylogeny_df.lazy().select("id").collect().to_series(),

--- a/phyloframe/legacy/_alifestd_to_working_format_polars.py
+++ b/phyloframe/legacy/_alifestd_to_working_format_polars.py
@@ -1,0 +1,158 @@
+import argparse
+import logging
+import os
+
+import joinem
+from joinem._dataframe_cli import _add_parser_base, _run_dataframe_cli
+import polars as pl
+
+from .._auxlib._add_bool_arg import add_bool_arg
+from .._auxlib._begin_prod_logging import begin_prod_logging
+from .._auxlib._format_cli_description import format_cli_description
+from .._auxlib._get_phyloframe_version import get_phyloframe_version
+from .._auxlib._log_context_duration import log_context_duration
+from ._alifestd_assign_contiguous_ids_polars import (
+    alifestd_assign_contiguous_ids_polars,
+)
+from ._alifestd_has_contiguous_ids_polars import (
+    alifestd_has_contiguous_ids_polars,
+)
+from ._alifestd_is_topologically_sorted_polars import (
+    alifestd_is_topologically_sorted_polars,
+)
+from ._alifestd_make_ancestor_list_col_polars import (
+    alifestd_make_ancestor_list_col_polars,
+)
+from ._alifestd_topological_sort_polars import (
+    alifestd_topological_sort_polars,
+)
+from ._alifestd_try_add_ancestor_id_col_polars import (
+    alifestd_try_add_ancestor_id_col_polars,
+)
+
+
+def alifestd_to_working_format_polars(
+    phylogeny_df: pl.DataFrame,
+    keep_ancestor_list: bool = False,
+) -> pl.DataFrame:
+    """Re-encode phylogeny_df to facilitate efficient analysis and
+    transformation operations.
+
+    The returned phylogeny dataframe will
+    * be topologically sorted (i.e., organisms appear after all ancestors),
+    * have contiguous ids (i.e., organisms' ids correspond to row number),
+    * contain an integer datatype `ancestor_id` column if the phylogeny is
+    asexual (i.e., a more performant representation of `ancestor_list`).
+
+    Parameters
+    ----------
+    phylogeny_df : polars.DataFrame
+        The phylogeny as a dataframe in alife standard format.
+    keep_ancestor_list : bool, default False
+        If True, regenerate the `ancestor_list` column from the (reassigned)
+        `ancestor_id` column. If False, the `ancestor_list` column is dropped.
+
+    See Also
+    --------
+    alifestd_to_working_format :
+        Pandas-based implementation.
+    """
+    phylogeny_df = alifestd_try_add_ancestor_id_col_polars(phylogeny_df)
+
+    if "ancestor_list" in phylogeny_df.lazy().collect_schema().names():
+        phylogeny_df = phylogeny_df.drop("ancestor_list")
+
+    if not alifestd_has_contiguous_ids_polars(phylogeny_df):
+        phylogeny_df = alifestd_assign_contiguous_ids_polars(phylogeny_df)
+
+    if not alifestd_is_topologically_sorted_polars(phylogeny_df):
+        phylogeny_df = alifestd_topological_sort_polars(phylogeny_df)
+        phylogeny_df = alifestd_assign_contiguous_ids_polars(phylogeny_df)
+
+    if keep_ancestor_list:
+        phylogeny_df = phylogeny_df.with_columns(
+            ancestor_list=alifestd_make_ancestor_list_col_polars(
+                phylogeny_df.lazy().select("id").collect().to_series(),
+                phylogeny_df.lazy()
+                .select("ancestor_id")
+                .collect()
+                .to_series(),
+            ),
+        )
+
+    return phylogeny_df
+
+
+_raw_description = f"""{os.path.basename(__file__)} | (phyloframe v{get_phyloframe_version()}/joinem v{joinem.__version__})
+
+Re-encode phylogeny_df to facilitate efficient analysis and transformation operations.
+
+The returned phylogeny dataframe will
+- be topologically sorted (i.e., organisms appear after all ancestors),
+- have contiguous ids (i.e., organisms' ids correspond to row number),
+- contain an integer datatype `ancestor_id` column if the phylogeny is asexual (i.e., a more performant representation of `ancestor_list`).
+
+Data is assumed to be in alife standard format.
+
+Additional Notes
+================
+- Use `--eager-read` if modifying data file inplace.
+
+- This CLI entrypoint is experimental and may be subject to change.
+
+See Also
+========
+phyloframe.legacy._alifestd_to_working_format :
+    CLI entrypoint for Pandas-based implementation.
+"""
+
+
+def _create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        add_help=False,
+        allow_abbrev=False,
+        description=format_cli_description(_raw_description),
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser = _add_parser_base(
+        parser=parser,
+        dfcli_module="phyloframe.legacy._alifestd_to_working_format_polars",
+        dfcli_version=get_phyloframe_version(),
+    )
+    add_bool_arg(
+        parser,
+        "keep-ancestor-list",
+        default=False,
+        help=(
+            "regenerate the `ancestor_list` column from the reassigned "
+            "`ancestor_id` column instead of dropping it (default: False)"
+        ),
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    begin_prod_logging()
+
+    parser = _create_parser()
+    args, __ = parser.parse_known_args()
+
+    try:
+        with log_context_duration(
+            "phyloframe.legacy._alifestd_to_working_format_polars",
+            logging.info,
+        ):
+            _run_dataframe_cli(
+                base_parser=parser,
+                output_dataframe_op=(
+                    lambda df: alifestd_to_working_format_polars(
+                        df,
+                        keep_ancestor_list=args.keep_ancestor_list,
+                    )
+                ),
+            )
+    except NotImplementedError as e:
+        logging.error(
+            "- polars op not yet implemented, use pandas op CLI instead",
+        )
+        raise e

--- a/tests/test_phyloframe/test_legacy/test_alifestd_to_working_format_polars.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_to_working_format_polars.py
@@ -1,0 +1,254 @@
+import typing
+
+import polars as pl
+import pytest
+
+from phyloframe.legacy._alifestd_has_contiguous_ids_polars import (
+    alifestd_has_contiguous_ids_polars,
+)
+from phyloframe.legacy._alifestd_is_topologically_sorted_polars import (
+    alifestd_is_topologically_sorted_polars,
+)
+from phyloframe.legacy._alifestd_to_working_format_polars import (
+    alifestd_to_working_format_polars as alifestd_to_working_format_polars_,
+)
+
+from ._impl import enforce_dtype_stability_polars
+
+alifestd_to_working_format_polars = enforce_dtype_stability_polars(
+    alifestd_to_working_format_polars_
+)
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_alifestd_to_working_format_polars_already_working(
+    apply: typing.Callable,
+):
+    """Already-working data is left in working format."""
+    df_pl = apply(
+        pl.DataFrame(
+            {
+                "id": [0, 1, 2, 3, 4],
+                "ancestor_id": [0, 0, 0, 1, 1],
+            }
+        ),
+    )
+
+    result = alifestd_to_working_format_polars(df_pl).lazy().collect()
+
+    assert len(result) == 5
+    assert alifestd_has_contiguous_ids_polars(result)
+    assert alifestd_is_topologically_sorted_polars(result)
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_alifestd_to_working_format_polars_unsorted(
+    apply: typing.Callable,
+):
+    """Topologically unsorted, contiguous-id data gets sorted."""
+    df_pl = apply(
+        pl.DataFrame(
+            {
+                "id": [4, 3, 2, 1, 0],
+                "ancestor_id": [1, 1, 0, 0, 0],
+            }
+        ),
+    )
+
+    result = alifestd_to_working_format_polars(df_pl).lazy().collect()
+
+    assert len(result) == 5
+    assert alifestd_has_contiguous_ids_polars(result)
+    assert alifestd_is_topologically_sorted_polars(result)
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_alifestd_to_working_format_polars_non_contiguous_ids(
+    apply: typing.Callable,
+):
+    """Non-contiguous ids get reassigned to row indices."""
+    df_pl = apply(
+        pl.DataFrame(
+            {
+                "id": [10, 20, 30, 40, 50],
+                "ancestor_id": [10, 10, 10, 20, 20],
+            }
+        ),
+    )
+
+    result = alifestd_to_working_format_polars(df_pl).lazy().collect()
+
+    assert len(result) == 5
+    assert alifestd_has_contiguous_ids_polars(result)
+    assert alifestd_is_topologically_sorted_polars(result)
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_alifestd_to_working_format_polars_unsorted_non_contiguous(
+    apply: typing.Callable,
+):
+    """Unsorted, non-contiguous data is fully normalized."""
+    df_pl = apply(
+        pl.DataFrame(
+            {
+                "id": [50, 40, 30, 20, 10],
+                "ancestor_id": [20, 20, 10, 10, 10],
+            }
+        ),
+    )
+
+    result = alifestd_to_working_format_polars(df_pl).lazy().collect()
+
+    assert len(result) == 5
+    assert alifestd_has_contiguous_ids_polars(result)
+    assert alifestd_is_topologically_sorted_polars(result)
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_alifestd_to_working_format_polars_single_node(
+    apply: typing.Callable,
+):
+    """Single node is trivially in working format."""
+    df_pl = apply(
+        pl.DataFrame(
+            {
+                "id": [0],
+                "ancestor_id": [0],
+            }
+        ),
+    )
+
+    result = alifestd_to_working_format_polars(df_pl).lazy().collect()
+
+    assert result["id"].to_list() == [0]
+    assert alifestd_has_contiguous_ids_polars(result)
+    assert alifestd_is_topologically_sorted_polars(result)
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_alifestd_to_working_format_polars_adds_ancestor_id(
+    apply: typing.Callable,
+):
+    """Asexual data with only ancestor_list gets an ancestor_id column."""
+    df_pl = apply(
+        pl.DataFrame(
+            {
+                "id": [0, 1, 2, 3, 4],
+                "ancestor_list": ["[none]", "[0]", "[0]", "[1]", "[1]"],
+            }
+        ),
+    )
+
+    result = alifestd_to_working_format_polars(df_pl).lazy().collect()
+
+    assert "ancestor_id" in result.columns
+    assert "ancestor_list" not in result.columns
+    assert alifestd_has_contiguous_ids_polars(result)
+    assert alifestd_is_topologically_sorted_polars(result)
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_alifestd_to_working_format_polars_drops_ancestor_list(
+    apply: typing.Callable,
+):
+    """By default, ancestor_list is dropped from the result."""
+    df_pl = apply(
+        pl.DataFrame(
+            {
+                "id": [10, 20, 30, 40, 50],
+                "ancestor_id": [10, 10, 10, 20, 20],
+                "ancestor_list": ["[none]", "[10]", "[10]", "[20]", "[20]"],
+            }
+        ),
+    )
+
+    result = alifestd_to_working_format_polars(df_pl).lazy().collect()
+
+    assert "ancestor_list" not in result.columns
+    assert "ancestor_id" in result.columns
+    assert alifestd_has_contiguous_ids_polars(result)
+    assert alifestd_is_topologically_sorted_polars(result)
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_alifestd_to_working_format_polars_keep_ancestor_list(
+    apply: typing.Callable,
+):
+    """When keep_ancestor_list=True, ancestor_list is regenerated."""
+    df_pl = apply(
+        pl.DataFrame(
+            {
+                "id": [10, 20, 30, 40, 50],
+                "ancestor_id": [10, 10, 10, 20, 20],
+                "ancestor_list": ["[none]", "[10]", "[10]", "[20]", "[20]"],
+            }
+        ),
+    )
+
+    result = (
+        alifestd_to_working_format_polars(df_pl, keep_ancestor_list=True)
+        .lazy()
+        .collect()
+    )
+
+    assert "ancestor_list" in result.columns
+    assert "ancestor_id" in result.columns
+    assert alifestd_has_contiguous_ids_polars(result)
+    assert alifestd_is_topologically_sorted_polars(result)
+    # root has [none], rest reference reassigned ancestor ids
+    ids = result["id"].to_list()
+    ancestor_ids = result["ancestor_id"].to_list()
+    ancestor_lists = result["ancestor_list"].to_list()
+    for nid, aid, alist in zip(ids, ancestor_ids, ancestor_lists):
+        if nid == aid:
+            assert alist == "[none]"
+        else:
+            assert alist == f"[{aid}]"

--- a/tests/test_phyloframe/test_legacy/test_alifestd_to_working_format_polars.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_to_working_format_polars.py
@@ -219,6 +219,38 @@ def test_alifestd_to_working_format_polars_drops_ancestor_list(
         pytest.param(lambda x: x.lazy(), id="LazyFrame"),
     ],
 )
+def test_alifestd_to_working_format_polars_keep_ancestor_list_absent(
+    apply: typing.Callable,
+):
+    """keep_ancestor_list=True is a no-op when input had no ancestor_list."""
+    df_pl = apply(
+        pl.DataFrame(
+            {
+                "id": [10, 20, 30, 40, 50],
+                "ancestor_id": [10, 10, 10, 20, 20],
+            }
+        ),
+    )
+
+    result = (
+        alifestd_to_working_format_polars(df_pl, keep_ancestor_list=True)
+        .lazy()
+        .collect()
+    )
+
+    assert "ancestor_list" not in result.columns
+    assert "ancestor_id" in result.columns
+    assert alifestd_has_contiguous_ids_polars(result)
+    assert alifestd_is_topologically_sorted_polars(result)
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
 def test_alifestd_to_working_format_polars_keep_ancestor_list(
     apply: typing.Callable,
 ):

--- a/tests/test_phyloframe/test_legacy/test_alifestd_to_working_format_polars_cli.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_to_working_format_polars_cli.py
@@ -1,0 +1,105 @@
+import os
+import pathlib
+import subprocess
+
+import pandas as pd
+
+assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
+
+
+def test_alifestd_to_working_format_polars_cli_help():
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "phyloframe.legacy._alifestd_to_working_format_polars",
+            "--help",
+        ],
+        check=True,
+    )
+
+
+def test_alifestd_to_working_format_polars_cli_version():
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "phyloframe.legacy._alifestd_to_working_format_polars",
+            "--version",
+        ],
+        check=True,
+    )
+
+
+def test_alifestd_to_working_format_polars_cli_csv():
+    output_file = (
+        "/tmp/phyloframe_alifestd_to_working_format_polars.csv"  # nosec B108
+    )
+    pathlib.Path(output_file).unlink(missing_ok=True)
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "phyloframe.legacy._alifestd_to_working_format_polars",
+            "--eager-write",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/trunktestphylo.csv".encode(),
+    )
+    assert os.path.exists(output_file)
+    result_df = pd.read_csv(output_file)
+    assert len(result_df) > 0
+    assert "id" in result_df.columns
+
+
+def test_alifestd_to_working_format_polars_cli_parquet():
+    output_file = (
+        "/tmp/phyloframe_alifestd_to_working_format_polars.pqt"  # nosec B108
+    )
+    pathlib.Path(output_file).unlink(missing_ok=True)
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "phyloframe.legacy._alifestd_to_working_format_polars",
+            "--eager-write",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/trunktestphylo.csv".encode(),
+    )
+    assert os.path.exists(output_file)
+    result_df = pd.read_parquet(output_file)
+    assert len(result_df) > 0
+    assert "id" in result_df.columns
+
+
+def test_alifestd_to_working_format_polars_cli_keep_ancestor_list():
+    output_file = "/tmp/phyloframe_alifestd_to_working_format_polars_keep.csv"  # nosec B108
+    pathlib.Path(output_file).unlink(missing_ok=True)
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "phyloframe.legacy._alifestd_to_working_format_polars",
+            "--keep-ancestor-list",
+            "--eager-write",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/trunktestphylo.csv".encode(),
+    )
+    assert os.path.exists(output_file)
+    result_df = pd.read_csv(output_file)
+    assert "ancestor_list" in result_df.columns
+    assert "ancestor_id" in result_df.columns
+
+
+def test_alifestd_to_working_format_polars_create_parser():
+    from phyloframe.legacy._alifestd_to_working_format_polars import (
+        _create_parser,
+    )
+
+    parser = _create_parser()
+    assert parser is not None

--- a/tests/test_phyloframe/test_legacy/test_alifestd_to_working_format_polars_cli.py
+++ b/tests/test_phyloframe/test_legacy/test_alifestd_to_working_format_polars_cli.py
@@ -88,11 +88,31 @@ def test_alifestd_to_working_format_polars_cli_keep_ancestor_list():
             output_file,
         ],
         check=True,
-        input=f"{assets}/trunktestphylo.csv".encode(),
+        input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
     )
     assert os.path.exists(output_file)
     result_df = pd.read_csv(output_file)
     assert "ancestor_list" in result_df.columns
+    assert "ancestor_id" in result_df.columns
+
+
+def test_alifestd_to_working_format_polars_cli_drops_ancestor_list():
+    output_file = "/tmp/phyloframe_alifestd_to_working_format_polars_drop.csv"  # nosec B108
+    pathlib.Path(output_file).unlink(missing_ok=True)
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "phyloframe.legacy._alifestd_to_working_format_polars",
+            "--eager-write",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
+    )
+    assert os.path.exists(output_file)
+    result_df = pd.read_csv(output_file)
+    assert "ancestor_list" not in result_df.columns
     assert "ancestor_id" in result_df.columns
 
 


### PR DESCRIPTION
Implements a polars equivalent of alifestd_to_working_format that adds
ancestor_id, assigns contiguous ids, and topologically sorts the
phylogeny. Adds a keep_ancestor_list flag to optionally regenerate the
ancestor_list column from the reassigned ancestor_id column.